### PR TITLE
Snake-content Folder

### DIFF
--- a/snake-editor/theme.py
+++ b/snake-editor/theme.py
@@ -12,10 +12,9 @@ import os
 import shutil
 import sys
 
-from kano.utils import ensure_dir,get_home
+from kano.utils import ensure_dir
 
-home= get_home()
-app_dir = home + '/Snake-content'
+app_dir = os.path.expanduser('~/Snake-content')
 custom_file = app_dir + '/custom_theme'
 colors_map = {}
 theme = {

--- a/snake/theme.py
+++ b/snake/theme.py
@@ -12,10 +12,8 @@ import parser
 import themes
 import xml.etree.ElementTree as ET
 
-from kano.utils import ensure_dir,get_home
-
-home = get_home()
-app_dir = home + '/Snake-content'
+from kano.utils import ensure_dir
+app_dir = os.path.expanduser( '~/Snake-content')
 custom_file = app_dir + '/custom_theme'
 colors_map = {}
 theme = None


### PR DESCRIPTION
Applying the fix discussed in the other pull request. Went with the os.path.expanduser(), seemed to be cleaner.
