### PR TITLE
Errors in playground will not clear screen https://github.com/KanoComput...

### DIFF
--- a/bin/make-snake
+++ b/bin/make-snake
@@ -247,8 +247,12 @@ if [ "$stage" -ge 9 ]; then
           done
           # Launch game
           python -B $dir $param
+          rc=$?
+          # Check if snake exited due to parsing parameters
+          if [ $rc == 2 ]; then
+              breakline
           # Check if the command contains a help option
-          if [[ $param == *"--help"* ]] || [[ $param == *"-h"* ]]; then
+          elif [[ $param == *"--help"* ]] || [[ $param == *"-h"* ]]; then
               breakline
           else
               # Clean terminal + header

--- a/snake/parser.py
+++ b/snake/parser.py
@@ -75,6 +75,4 @@ def init():
                         action="store_true", dest="tutorial", default=False,
                         help="Closes game after game over")
 
-    # the argument parser prints a message when an incorrect argument was given then exits
-    # this will cause the screen to be cleared immediately, so we catch the exit
     args = parser.parse_args()


### PR DESCRIPTION
- Error handling in the parser is set to exit with `return code = 2`
- The executable can then 'keep an eye out' for this an avoid clearing the screen

https://github.com/KanoComputing/peldins/issues/1095
