### PR TITLE
Add MIME type information to .app file

### DIFF
--- a/icon/make-snake.app
+++ b/icon/make-snake.app
@@ -8,6 +8,7 @@
     "colour": "#d94e5a",
 
     "categories": ["code"],
+    "mime_type": "application/x-kano-make-snake",
 
     "packages": [],
     "dependencies": ["make-snake"],


### PR DESCRIPTION
KanoComputing/peldins#1511
Adds MIME type information to the .app file so that the autogenerated
.desktop file contains the MimeType field. To be used in conjunction
with
KanoComputing/kano-apps/commit/d2e3e28e44ec4f92a586fdc0718aca1a741e6d2f