### PR TITLE
Refresh the whole board when the controls are used

### DIFF
--- a/snake-editor/controls.py
+++ b/snake-editor/controls.py
@@ -10,7 +10,6 @@
 #
 
 import os
-import time
 import re
 import curses
 import graphics
@@ -42,7 +41,11 @@ tile = ''
 
 def redraw_board():
     gameloop.init()
-    theme.update()  # This is going to create the new theme if it doesnt exist
+    theme.update()  # This is going to create the new theme if it doesn't exist
+
+    # Force the game to update
+    graphics.drawGame()
+    graphics.update()
 
 
 def update():


### PR DESCRIPTION
https://github.com/KanoComputing/peldins/issues/1851

A related bug to this was that the background (and other) symbols were always of the previous selection.

I never identified why the colours updated and the symbols did not (when I logged the output, it appeared that both or neither should update, since the information update and redrawing of the colours and symbols seemed to be happen at the same time), but by forcing an extra update, the problem seems to have gone away. This solution could be a bit heavy handed, but the performance seems to be fine after this change.
