### PR TITLE
Board Size: Use Gdk to get screen size

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Build-Depends: debhelper (>=9.0.0)
 Package: make-snake
 Architecture: all
 Depends: ${misc:Depends}, rxvt-unicode-256color, python,
- kano-profile (>=2.3.0-2), kano-toolset (>=1.3-8), kano-settings
+ kano-profile (>=2.3.0-2), kano-toolset (>=1.3-8)
 Description: Lightweight, configurable snake game running in the console

--- a/snake-editor/stage.py
+++ b/snake-editor/stage.py
@@ -10,9 +10,9 @@ import console
 import math
 import time
 import os
+from gtk import gdk
 
 from kano.window import _get_window_by_child_pid, gdk_window_settings
-from kano_settings.system.display import get_status
 
 
 def init():
@@ -24,9 +24,10 @@ def init():
     gdk_window_settings(win, maximized=True)
     time.sleep(0.1)
     available_size = (width, height) = console.getTerminalSize()
+
      # Check for screen resolution
-    resolution = get_status()['resolution']
-    resolution = int(resolution.split('x')[1])
+    resolution = gdk.screen_height()
+
     # Select a set of sizes depending on the screen resolution
     if resolution > 768:
         chosen_size = (20, 15)

--- a/snake/stage.py
+++ b/snake/stage.py
@@ -13,9 +13,9 @@ import parser
 import __main__
 import os
 import time
+from gtk import gdk
 
 from kano.window import _get_window_by_child_pid, gdk_window_settings
-from kano_settings.system.display import get_status
 
 
 def init():
@@ -30,8 +30,8 @@ def init():
 
     try:
         # Check for screen resolution
-        resolution = get_status()['resolution']
-        h = int(resolution.split('x')[1])
+        h = gdk.screen_height()
+
         # Select a set of sizes depending on the screen resolution
         if h > 1024:
             chosen_size = config.game_sizes_big[parser.args.board]

--- a/snake/stage.py
+++ b/snake/stage.py
@@ -40,8 +40,9 @@ def init():
         else:
             chosen_size = config.game_sizes_small[parser.args.board]
         passSize = parser.args.board
-    except:
-        print "Can't find board size: %s" % (parser.args.board)
+    except Exception:
+        from kano.logging import logger
+        logger.error("Can't find board size: {}".format(parser.args.board))
         __main__.exit()
 
     # Calculate width


### PR DESCRIPTION
When retrieving the screen size to be able to correctly set the game
board size, Kano Settings is utilised. This fails because reading the
settings has become read-protected and so the whole game fails to
launch. Bypass this problem by reading the screen size directly from
Gdk.

cc @Ealdwulf @radujipa @pazdera 