### PR TITLE
Board Size: Prevent the wrong size being set

### DIFF
--- a/snake/stage.py
+++ b/snake/stage.py
@@ -35,7 +35,7 @@ def init():
         # Select a set of sizes depending on the screen resolution
         if h > 1024:
             chosen_size = config.game_sizes_big[parser.args.board]
-        if h <= 1024 and h > 720:
+        elif h <= 1024 and h > 720:
             chosen_size = config.game_sizes_medium[parser.args.board]
         else:
             chosen_size = config.game_sizes_small[parser.args.board]


### PR DESCRIPTION
When setting the board size a check is made to see if the screen is big
enough. This follows a series of checks, starting with the largest then
checking for medium and finally small. Unfortunately, the small setting
ends up being set for both the large and small size. Resolve this by
fixing the flow.

@radujipa @Ealdwulf @pazdera 