### PR TITLE
Dependencies: Add gtk2 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: make-snake
 Architecture: all
-Depends: ${misc:Depends}, rxvt-unicode-256color, python,
+Depends: ${misc:Depends}, rxvt-unicode-256color, python, python-gtk2,
  kano-profile (>=2.3.0-2), kano-toolset (>=1.3-8)
 Description: Lightweight, configurable snake game running in the console


### PR DESCRIPTION
Commit 54e8991ae5f2f896811402ef5c3e46d741ad4943 uses gdk (from gtk2) to
acquire the screen size. This is implicitly depended on via kano-toolset
dependency but depend explicitly.

@pazdera to review