### PR TITLE
Created a custom snake launcher for Kano Overworld

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+make-snake (3.0.0-1) unstable; urgency=low
+
+  * Added game launcher for Kano Overworld
+
+ -- Team Kano <dev@kano.me>  Thu, 8 Apr 2016 15:29:00 +0000
+
 make-snake (2.3.0-1) unstable; urgency=low
 
   * Integrate with latest kano-profile

--- a/snake/snake-launch-overworld.sh
+++ b/snake/snake-launch-overworld.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/kano-splash /usr/share/make-snake/media/splash.png /bin/sh
+rxvt -title 'Make Snake' -e make-snake &
+pid=$!
+
+sleep 1
+wmctrl -r "Make Snake" -b toggle,maximized_vert,maximized_horz
+
+while kill -0 $pid 2> /dev/null; do
+    sleep 1
+done

--- a/snake/snake-launch-overworld.sh
+++ b/snake/snake-launch-overworld.sh
@@ -12,6 +12,4 @@ pid=$!
 sleep 1
 wmctrl -r "Make Snake" -b toggle,maximized_vert,maximized_horz
 
-while kill -0 $pid 2> /dev/null; do
-    sleep 1
-done
+wait $pid

--- a/snake/snake-launch-overworld.sh
+++ b/snake/snake-launch-overworld.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/kano-splash /usr/share/make-snake/media/splash.png /bin/sh
+# snake-launch-overworld.sh
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+#
+# This is the game launcher script used by kano-overworld
+
 rxvt -title 'Make Snake' -e make-snake &
 pid=$!
 

--- a/snake/snake-launch.sh
+++ b/snake/snake-launch.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/kano-splash /usr/share/make-snake/media/splash.png /bin/sh
+# snake-launch.sh
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+#
+# This is the game launcher script used in conjunction with kano-launcher
+
 rxvt -title 'Make Snake' -e make-snake


### PR DESCRIPTION
This launcher starts Make Snake and maximises its `rxvt`. Afterwards, it keeps the script running until `rxvt` is closed. This spec comes from `Kano Overworld`'s way of launching apps one after another.