### PR TITLE
I18n support & Japanese translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .DS_Store
 *~
+.mo
+po/messages.pot

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,61 @@
+# Translation
+
+Translation files are found in the `po/` directory.
+
+## i18n not released yet
+
+Kano OS is not fully i18n-aware and locales are not installed for end users, yet. You can translate this application, but as of now, users will still see the default English message strings.
+
+## How to add a new translation
+
+In this example, we're going to add a French translation:
+
+    # install your target locale `fr_FR.utf8` with:
+    sudo dpkg-reconfigure locales
+    
+    cd po/
+    # create messages.pot
+    make messages
+    
+    # create fr.po from messages.pot:
+    msginit -l fr_FR.utf8
+    
+    # now use your favourite editor to translate fr.po
+    
+    # build locale files:
+    make
+    
+    cd ..
+
+    # when testing, make sure LC_ALL is set to your locale e.g.
+    LC_ALL=fr_FR.utf8
+
+## How to make sure your code is i18n-aware
+
+Add the gettext `_()` macro to all the user-visible message strings in your Python. List the Python source files that contain message strings in `PYPOTFILES`.
+
+If you added new message strings or made changes to existing ones, do `make messages` to keep the template file up-to-date.
+
+After that, merge the existing translations with `make update` and ask your translators to update their translations.
+
+## gettext explained (in 20 seconds)
+
+* User-visible strings in the source are marked with a macro of your choice. Usually, it's `_()`.
+* `xgettext` extracts these message strings from your sources and puts them into a template file.
+* This template file, usually named `messages.pot`, contains all user-visible strings of the project, but no translations.
+* Translators use `msginit` to copy the template file into a new *portable object* file for their language (explained above).
+* The translations are put into `<lang>.po`. It's a plain-text file format, you can use any text editor.
+* More convenient, specialized `.po`-editors and web-based tools such as Pootle exist, as well.
+* If your template file changes, use `msgmerge` to merge your existing translations with the new template, then re-translate the updated messages. Beware of `msgmerge`'s "fuzzy" matches.
+* `msgfmt` converts a `.po` file into a binary *message object* file.
+* You don't link these `.mo` files with your application binary.
+* The `.mo` files are bundled alongside with your software as part of the distribution package.
+* During installation, the `.mo` files are copied into the system's locale directory, usually `/usr/share/locale`.
+* On startup, your application will look for the message object file that it needs for the current system locale.
+* The locale even allows you to provide region-specific translations, e.g. "colour" for en_UK vs "color" for en_US.
+* At runtime, all user-visible strings are being replaced with the translations.
+* If no message object was found for the system locale, the original strings will be shown. 
+
+## To-Do
+
+Pootle or Transifex integration.

--- a/bin/make-snake
+++ b/bin/make-snake
@@ -18,6 +18,8 @@ trap kanotracker EXIT
 
 dir="/usr/share/make-snake"
 
+alias GETTEXT='gettext "make-snake"'
+
 function breakline
 {
     echo -ne "\n"
@@ -50,13 +52,13 @@ function inputLoop
         read -erp $'    \1\e[96m\2>\1\e[0m\2 ' command
         history -s $command
         if [ -z "$command" ]; then
-            colourEcho "{{6 - }} {{5 Need to enter a command: }} {{2 $1 }} {{5 or }} {{2 exit }}"
+            colourEcho $(GETTEXT "{{6 - }} {{5 Need to enter a command: }} {{2 \$1 }} {{5 or }} {{2 exit }}")
         elif [ "$command" == "$1" ] || [ "$command" == "$2" ]; then
             break
         elif [ "$command" == "exit" ]; then
             exit
         fi
-        colourEcho "Type {{2 $1 }} then {{1 ENTER }}"
+        colourEcho $(GETTEXT "Type {{2 \$1 }} then {{1 ENTER }}")
         breakline
     done
 }
@@ -86,7 +88,7 @@ function printGainedExp
 {
     if [ "$gained_exp" -gt 0 ]; then
         breakline
-        typewriter_echo "Fantastic! You gained {{2 $gained_exp }} experience points!" 0 2 1 0
+        typewriter_echo $(GETTEXT "Fantastic! You gained {{2 \$gained_exp }} experience points!") 0 2 1 0
     fi
 }
 
@@ -117,7 +119,7 @@ else
     mod_stage=$(($stage % 10))
     if [ ! "$mod_stage" -ge 8 ] && [ ! "$mod_stage" -eq 0 ]; then
         header
-        typewriter_echo "Where were we..." 0 2 1 0
+        typewriter_echo $(GETTEXT "Where were we...") 0 2 1 0
     fi
 fi
 
@@ -126,12 +128,12 @@ kano-stop-splash
 # Exercise 1: 'press ENTER'
 if [ "$mod_stage" -eq 0 ]; then
     header
-    colourEcho "{{3Challenge [1/9]: Let's play!}}"
+    colourEcho $(GETTEXT "{{3Challenge [1/9]: Let's play!}}")
     breakline
     breakline
-    typewriter_echo "Snake is one of the oldest and coolest games." 0 2 1 0
-    typewriter_echo "Eat apples, but don't bite your tail!" 0 2 1 0
-    typewriter_echo "Press {{1 ENTER }} to see what you'll make!" 0 0 1 0
+    typewriter_echo $(GETTEXT "Snake is one of the oldest and coolest games.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Eat apples, but don't bite your tail!") 0 2 1 0
+    typewriter_echo $(GETTEXT "Press {{1 ENTER }} to see what you'll make!") 0 0 1 0
 
     read
     # tutorial mode (-m), slow (-s s), large (-b l), 80s (-t 80s)
@@ -143,14 +145,14 @@ fi
 # Exercise 2: 'python snake'
 if [ "$mod_stage" -eq 1 ]; then
     header
-    colourEcho "{{3Challenge [2/9]: Your first spell}}"
+    colourEcho $(GETTEXT "{{3Challenge [2/9]: Your first spell}}")
     breakline
     breakline
-    typewriter_echo "Ready to make it?" 0 2 1 0
-    typewriter_echo "Let's start simple." 0 2 1 0
-    typewriter_echo "Type {{2 python snake }} then press {{1 ENTER }}." 0 2 1 0
-    typewriter_echo "This is a Linux command – a spell that your computer's brain understands." 0 2 1 0
-    typewriter_echo "You can type {{2 exit }} at any point to quit." 0 2 1 0
+    typewriter_echo $(GETTEXT "Ready to make it?") 0 2 1 0
+    typewriter_echo $(GETTEXT "Let's start simple.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake }} then press {{1 ENTER }}.") 0 2 1 0
+    typewriter_echo $(GETTEXT "This is a Linux command - a spell that your computer's brain understands.") 0 2 1 0
+    typewriter_echo $(GETTEXT "You can type {{2 exit }} at any point to quit.") 0 2 1 0
 
     inputLoop 'python snake'
     # tutorial mode (-m), slow (-s s)
@@ -162,13 +164,13 @@ fi
 # Exercise 3: 'python snake -b m'
 if [ "$mod_stage" -eq 2 ]; then
     header
-    colourEcho "{{3Challenge [3/9]: Game changer}}"
+    colourEcho $(GETTEXT "{{3Challenge [3/9]: Game changer}}")
     breakline
     breakline
-    typewriter_echo "Want to make the game tougher?" 0 2 1 0
-    typewriter_echo "{{2 python snake }} launches the game." 0 2 1 0
-    typewriter_echo "But you can write parameters after {{2 python snake }} to change how the game works." 0 2 1 0
-    typewriter_echo "You can make the board medium size with {{2 python snake -b m }}" 0 2 1 0
+    typewriter_echo $(GETTEXT "Want to make the game tougher?") 0 2 1 0
+    typewriter_echo $(GETTEXT "{{2 python snake }} launches the game.") 0 2 1 0
+    typewriter_echo $(GETTEXT "But you can write parameters after {{2 python snake }} to change how the game works.") 0 2 1 0
+    typewriter_echo $(GETTEXT "You can make the board medium size with {{2 python snake -b m }}") 0 2 1 0
 
     inputLoop 'python snake -b m' 'python snake --board m'
     # tutorial mode (-m), medium (-b m), slow (-s s)
@@ -180,13 +182,13 @@ fi
 # Exercise 4: 'python snake -l 3'
 if [ "$mod_stage" -eq 3 ]; then
     header
-    colourEcho "{{3Challenge [4/9]: Long live Snake}}"
+    colourEcho $(GETTEXT "{{3Challenge [4/9]: Long live Snake}}")
     breakline
     breakline
-    typewriter_echo "Another way to change the game is to add extra lives!" 0 2 1 0
-    typewriter_echo "You can add extra lives by adding {{2 --lives }} and a number after {{2 python snake }}." 0 2 1 0
-    typewriter_echo "{{2 python snake }} is a command, and {{2 --lives }} is an argument." 0 2 1 0
-    typewriter_echo "Type {{2 python snake --lives 3 }} to make a game with three lives." 0 2 1 0
+    typewriter_echo $(GETTEXT "Another way to change the game is to add extra lives!") 0 2 1 0
+    typewriter_echo $(GETTEXT "You can add extra lives by adding {{2 --lives }} and a number after {{2 python snake }}.") 0 2 1 0
+    typewriter_echo $(GETTEXT "{{2 python snake }} is a command, and {{2 --lives }} is an argument.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake --lives 3 }} to make a game with three lives.") 0 2 1 0
 
     inputLoop 'python snake --lives 3' 'python snake -l 3'
     # tutorial mode (-m), 3 lives (-l 3)
@@ -198,12 +200,12 @@ fi
 # Exercise 5: 'python snake -s f'
 if [ "$mod_stage" -eq 4 ]; then
     header
-    colourEcho "{{3Challenge [5/9]: Speed it up}}"
+    colourEcho $(GETTEXT "{{3Challenge [5/9]: Speed it up}}")
     breakline
     breakline
-    typewriter_echo "Another way to increase difficulty is by changing the Snake's speed." 0 2 1 0
-    typewriter_echo "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast." 0 2 1 0
-    typewriter_echo "Let's try a fast game! {{2 python snake -s f }}" 0 2 1 0
+    typewriter_echo $(GETTEXT "Another way to increase difficulty is by changing the Snake's speed.") 0 2 1 0
+    typewriter_echo $(GETTEXT "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Let's try a fast game! {{2 python snake -s f }}") 0 2 1 0
 
     inputLoop 'python snake -s f' 'python snake --speed f'
     python -B $dir -ms f
@@ -214,12 +216,12 @@ fi
 # Exercise 6: 'python snake -t jungle'
 if [ "$mod_stage" -eq 5 ]; then
     header
-    colourEcho "{{3Challenge [6/9]: Amazon style}}"
+    colourEcho $(GETTEXT "{{3Challenge [6/9]: Amazon style}}")
     breakline
     breakline
-    typewriter_echo "You are changing Snake using computer commands." 0 2 1 0
-    typewriter_echo "Now try modifying its theme (how Snake looks)." 0 2 1 0
-    typewriter_echo "Type {{2 python snake -t jungle }} to play Amazon style!" 0 2 1 0
+    typewriter_echo $(GETTEXT "You are changing Snake using computer commands.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Now try modifying its theme (how Snake looks).") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake -t jungle }} to play Amazon style!") 0 2 1 0
 
     inputLoop 'python snake -t jungle' 'python snake --theme jungle'
     python -B $dir -mt jungle
@@ -230,11 +232,11 @@ fi
 # Exercise 7: 'python snake -e'
 if [ "$mod_stage" -eq 6 ]; then
     header
-    colourEcho "{{3Challenge [7/9]: Make my own theme}}"
+    colourEcho $(GETTEXT "{{3Challenge [7/9]: Make my own theme}}")
     breakline
     breakline
-    typewriter_echo "Do you know you can even create your own themes?" 0 2 1 0
-    typewriter_echo "Type {{2 python snake -e }} to open the theme editor." 0 2 1 0
+    typewriter_echo $(GETTEXT "Do you know you can even create your own themes?") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake -e }} to open the theme editor.") 0 2 1 0
 
     inputLoop 'python snake -e' 'python snake --editor'
     python -B $dir -me
@@ -245,12 +247,12 @@ fi
 # Exercise 8: 'python snake -t custom-theme'
 if [ "$mod_stage" -eq 7 ]; then
     header
-    colourEcho "{{3Challenge [8/9]: Show your colours}}"
+    colourEcho $(GETTEXT "{{3Challenge [8/9]: Show your colours}}")
     breakline
     breakline
     getLastCreatedTheme
-    typewriter_echo "It's looking good!" 0 2 1 0
-    typewriter_echo "Type {{2 python snake -t $theme_name }} to play with the design that you saved in the editor." 0 2 1 0
+    typewriter_echo $(GETTEXT "It's looking good!") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake -t \$theme_name }} to play with the design that you saved in the editor.") 0 2 1 0
     inputLoop "python snake -t $theme_name" "python snake --theme $theme_name"
     python -B $dir -mt $theme_name
     saveLevel
@@ -260,11 +262,11 @@ fi
 # Exercise 9: 'python snake --help'
 if [ "$mod_stage" -eq 8 ]; then
     header
-    colourEcho "{{3Challenge [9/9]: Life saver}}"
+    colourEcho $(GETTEXT "{{3Challenge [9/9]: Life saver}}")
     breakline
     breakline
-    typewriter_echo "Use the help option to learn all the different spells, with commands, arguments, and options." 0 2 1 0
-    typewriter_echo "Type {{2 python snake --help }} to get help." 0 2 1 0
+    typewriter_echo $(GETTEXT "Use the help option to learn all the different spells, with commands, arguments, and options.") 0 2 1 0
+    typewriter_echo $(GETTEXT "Type {{2 python snake --help }} to get help.") 0 2 1 0
 
     inputLoop 'python snake --help' 'python snake -h'
     python -B $dir --help | sed "s/^/    /"
@@ -272,18 +274,18 @@ if [ "$mod_stage" -eq 8 ]; then
     printGainedExp
 
     breakline
-    typewriter_echo "{{4 + }} {{3 Great! You've completed Make Snake!}}" 1 2 1 0
-    typewriter_echo "Press {{1 ENTER }} to continue" 0 0 1 0
+    typewriter_echo $(GETTEXT "{{4 + }} {{3 Great! You've completed Make Snake!}}") 1 2 1 0
+    typewriter_echo $(GETTEXT "Press {{1 ENTER }} to continue") 0 0 1 0
     read
 fi
 
 # Playground
 if [ "$mod_stage" -ge 9 ]; then
     header
-    colourEcho "{{3Playground mode}}"
+    colourEcho $(GETTEXT "{{3Playground mode}}")
     breakline
     breakline
-    typewriter_echo "Try what you have learned, type {{2 python snake --help }} for help" 0 2 1 0
+    typewriter_echo $(GETTEXT "Try what you have learned, type {{2 python snake --help }} for help") 0 2 1 0
     # Infinite loop
     while true; do
         # Read command
@@ -314,18 +316,18 @@ if [ "$mod_stage" -ge 9 ]; then
                 breakline
             # Check if command contains reset option
             elif [[ $param == *"--reset"* ]] || [[ $param == *"-r"* ]]; then
-                typewriter_echo "{{4 + }} {{3 Make Snake has been reset, closing now...}}" 1 2 1 0
+                typewriter_echo $(GETTEXT "{{4 + }} {{3 Make Snake has been reset, closing now...}}") 1 2 1 0
                 exit 0
             else
                 # Clean terminal + header
                 header
-                colourEcho "{{3Playground mode}}"
+                colourEcho $(GETTEXT "{{3Playground mode}}")
                 breakline
                 breakline
-                colourEcho "Remember: type {{2 python snake --help }} for help\n" 0 2 1 0
+                colourEcho $(GETTEXT "Remember: type {{2 python snake --help }} for help\n") 0 2 1 0
             fi
         else
-            colourEcho "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish." 0 2 1 0
+            colourEcho $(GETTEXT "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish.") 0 2 1 0
             breakline
         fi
     done

--- a/bin/make-snake
+++ b/bin/make-snake
@@ -18,7 +18,8 @@ trap kanotracker EXIT
 
 dir="/usr/share/make-snake"
 
-alias GETTEXT='gettext "make-snake"'
+. gettext.sh
+export TEXTDOMAIN="make-snake"
 
 function breakline
 {
@@ -52,13 +53,14 @@ function inputLoop
         read -erp $'    \1\e[96m\2>\1\e[0m\2 ' command
         history -s $command
         if [ -z "$command" ]; then
-            colourEcho $(GETTEXT "{{6 - }} {{5 Need to enter a command: }} {{2 \$1 }} {{5 or }} {{2 exit }}")
+            commandstr=$1
+            colourEcho "`eval_gettext "{{6 - }} {{5 Need to enter a command: }} {{2 \\\$commandstr }} {{5 or }} {{2 exit }}"`"
         elif [ "$command" == "$1" ] || [ "$command" == "$2" ]; then
             break
         elif [ "$command" == "exit" ]; then
             exit
         fi
-        colourEcho $(GETTEXT "Type {{2 \$1 }} then {{1 ENTER }}")
+        colourEcho "`gettext "Type {{2 \$1 }} then {{1 ENTER }}"`"
         breakline
     done
 }
@@ -88,7 +90,7 @@ function printGainedExp
 {
     if [ "$gained_exp" -gt 0 ]; then
         breakline
-        typewriter_echo $(GETTEXT "Fantastic! You gained {{2 \$gained_exp }} experience points!") 0 2 1 0
+        typewriter_echo "`eval_gettext "Fantastic! You gained {{2 \\\$gained_exp }} experience points!"`" 0 2 1 0
     fi
 }
 
@@ -119,7 +121,7 @@ else
     mod_stage=$(($stage % 10))
     if [ ! "$mod_stage" -ge 8 ] && [ ! "$mod_stage" -eq 0 ]; then
         header
-        typewriter_echo $(GETTEXT "Where were we...") 0 2 1 0
+        typewriter_echo "`gettext "Where were we..."`" 0 2 1 0
     fi
 fi
 
@@ -128,12 +130,12 @@ kano-stop-splash
 # Exercise 1: 'press ENTER'
 if [ "$mod_stage" -eq 0 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [1/9]: Let's play!}}")
+    colourEcho "`gettext "{{3Challenge [1/9]: Let's play!}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Snake is one of the oldest and coolest games.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Eat apples, but don't bite your tail!") 0 2 1 0
-    typewriter_echo $(GETTEXT "Press {{1 ENTER }} to see what you'll make!") 0 0 1 0
+    typewriter_echo "`gettext "Snake is one of the oldest and coolest games."`" 0 2 1 0
+    typewriter_echo "`gettext "Eat apples, but don't bite your tail!"`" 0 2 1 0
+    typewriter_echo "`gettext "Press {{1 ENTER }} to see what you'll make!"`" 0 0 1 0
 
     read
     # tutorial mode (-m), slow (-s s), large (-b l), 80s (-t 80s)
@@ -145,14 +147,14 @@ fi
 # Exercise 2: 'python snake'
 if [ "$mod_stage" -eq 1 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [2/9]: Your first spell}}")
+    colourEcho "`gettext "{{3Challenge [2/9]: Your first spell}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Ready to make it?") 0 2 1 0
-    typewriter_echo $(GETTEXT "Let's start simple.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake }} then press {{1 ENTER }}.") 0 2 1 0
-    typewriter_echo $(GETTEXT "This is a Linux command - a spell that your computer's brain understands.") 0 2 1 0
-    typewriter_echo $(GETTEXT "You can type {{2 exit }} at any point to quit.") 0 2 1 0
+    typewriter_echo "`gettext "Ready to make it?"`" 0 2 1 0
+    typewriter_echo "`gettext "Let's start simple."`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake }} then press {{1 ENTER }}."`" 0 2 1 0
+    typewriter_echo "`gettext "This is a Linux command - a spell that your computer's brain understands."`" 0 2 1 0
+    typewriter_echo "`gettext "You can type {{2 exit }} at any point to quit."`" 0 2 1 0
 
     inputLoop 'python snake'
     # tutorial mode (-m), slow (-s s)
@@ -164,13 +166,13 @@ fi
 # Exercise 3: 'python snake -b m'
 if [ "$mod_stage" -eq 2 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [3/9]: Game changer}}")
+    colourEcho "`gettext "{{3Challenge [3/9]: Game changer}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Want to make the game tougher?") 0 2 1 0
-    typewriter_echo $(GETTEXT "{{2 python snake }} launches the game.") 0 2 1 0
-    typewriter_echo $(GETTEXT "But you can write parameters after {{2 python snake }} to change how the game works.") 0 2 1 0
-    typewriter_echo $(GETTEXT "You can make the board medium size with {{2 python snake -b m }}") 0 2 1 0
+    typewriter_echo "`gettext "Want to make the game tougher?"`" 0 2 1 0
+    typewriter_echo "`gettext "{{2 python snake }} launches the game."`" 0 2 1 0
+    typewriter_echo "`gettext "But you can write parameters after {{2 python snake }} to change how the game works."`" 0 2 1 0
+    typewriter_echo "`gettext "You can make the board medium size with {{2 python snake -b m }}"`" 0 2 1 0
 
     inputLoop 'python snake -b m' 'python snake --board m'
     # tutorial mode (-m), medium (-b m), slow (-s s)
@@ -182,13 +184,13 @@ fi
 # Exercise 4: 'python snake -l 3'
 if [ "$mod_stage" -eq 3 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [4/9]: Long live Snake}}")
+    colourEcho "`gettext "{{3Challenge [4/9]: Long live Snake}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Another way to change the game is to add extra lives!") 0 2 1 0
-    typewriter_echo $(GETTEXT "You can add extra lives by adding {{2 --lives }} and a number after {{2 python snake }}.") 0 2 1 0
-    typewriter_echo $(GETTEXT "{{2 python snake }} is a command, and {{2 --lives }} is an argument.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake --lives 3 }} to make a game with three lives.") 0 2 1 0
+    typewriter_echo "`gettext "Another way to change the game is to add extra lives!"`" 0 2 1 0
+    typewriter_echo "`gettext "You can add extra lives by adding {{2 --lives }} and a number after {{2 python snake }}."`" 0 2 1 0
+    typewriter_echo "`gettext "{{2 python snake }} is a command, and {{2 --lives }} is an argument."`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake --lives 3 }} to make a game with three lives."`" 0 2 1 0
 
     inputLoop 'python snake --lives 3' 'python snake -l 3'
     # tutorial mode (-m), 3 lives (-l 3)
@@ -200,12 +202,12 @@ fi
 # Exercise 5: 'python snake -s f'
 if [ "$mod_stage" -eq 4 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [5/9]: Speed it up}}")
+    colourEcho "`gettext "{{3Challenge [5/9]: Speed it up}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Another way to increase difficulty is by changing the Snake's speed.") 0 2 1 0
-    typewriter_echo $(GETTEXT "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Let's try a fast game! {{2 python snake -s f }}") 0 2 1 0
+    typewriter_echo "`gettext "Another way to increase difficulty is by changing the Snake's speed."`" 0 2 1 0
+    typewriter_echo "`gettext "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast."`" 0 2 1 0
+    typewriter_echo "`gettext "Let's try a fast game! {{2 python snake -s f }}"`" 0 2 1 0
 
     inputLoop 'python snake -s f' 'python snake --speed f'
     python -B $dir -ms f
@@ -216,12 +218,12 @@ fi
 # Exercise 6: 'python snake -t jungle'
 if [ "$mod_stage" -eq 5 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [6/9]: Amazon style}}")
+    colourEcho "`gettext "{{3Challenge [6/9]: Amazon style}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "You are changing Snake using computer commands.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Now try modifying its theme (how Snake looks).") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake -t jungle }} to play Amazon style!") 0 2 1 0
+    typewriter_echo "`gettext "You are changing Snake using computer commands."`" 0 2 1 0
+    typewriter_echo "`gettext "Now try modifying its theme (how Snake looks)."`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake -t jungle }} to play Amazon style!"`" 0 2 1 0
 
     inputLoop 'python snake -t jungle' 'python snake --theme jungle'
     python -B $dir -mt jungle
@@ -232,11 +234,11 @@ fi
 # Exercise 7: 'python snake -e'
 if [ "$mod_stage" -eq 6 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [7/9]: Make my own theme}}")
+    colourEcho "`gettext "{{3Challenge [7/9]: Make my own theme}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Do you know you can even create your own themes?") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake -e }} to open the theme editor.") 0 2 1 0
+    typewriter_echo "`gettext "Do you know you can even create your own themes?"`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake -e }} to open the theme editor."`" 0 2 1 0
 
     inputLoop 'python snake -e' 'python snake --editor'
     python -B $dir -me
@@ -247,12 +249,12 @@ fi
 # Exercise 8: 'python snake -t custom-theme'
 if [ "$mod_stage" -eq 7 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [8/9]: Show your colours}}")
+    colourEcho "`gettext "{{3Challenge [8/9]: Show your colours}}"`"
     breakline
     breakline
     getLastCreatedTheme
-    typewriter_echo $(GETTEXT "It's looking good!") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake -t \$theme_name }} to play with the design that you saved in the editor.") 0 2 1 0
+    typewriter_echo "`gettext "It's looking good!"`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake -t \$theme_name }} to play with the design that you saved in the editor."`" 0 2 1 0
     inputLoop "python snake -t $theme_name" "python snake --theme $theme_name"
     python -B $dir -mt $theme_name
     saveLevel
@@ -262,11 +264,11 @@ fi
 # Exercise 9: 'python snake --help'
 if [ "$mod_stage" -eq 8 ]; then
     header
-    colourEcho $(GETTEXT "{{3Challenge [9/9]: Life saver}}")
+    colourEcho "`gettext "{{3Challenge [9/9]: Life saver}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Use the help option to learn all the different spells, with commands, arguments, and options.") 0 2 1 0
-    typewriter_echo $(GETTEXT "Type {{2 python snake --help }} to get help.") 0 2 1 0
+    typewriter_echo "`gettext "Use the help option to learn all the different spells, with commands, arguments, and options."`" 0 2 1 0
+    typewriter_echo "`gettext "Type {{2 python snake --help }} to get help."`" 0 2 1 0
 
     inputLoop 'python snake --help' 'python snake -h'
     python -B $dir --help | sed "s/^/    /"
@@ -274,18 +276,18 @@ if [ "$mod_stage" -eq 8 ]; then
     printGainedExp
 
     breakline
-    typewriter_echo $(GETTEXT "{{4 + }} {{3 Great! You've completed Make Snake!}}") 1 2 1 0
-    typewriter_echo $(GETTEXT "Press {{1 ENTER }} to continue") 0 0 1 0
+    typewriter_echo "`gettext "{{4 + }} {{3 Great! You've completed Make Snake!}}"`" 1 2 1 0
+    typewriter_echo "`gettext "Press {{1 ENTER }} to continue"`" 0 0 1 0
     read
 fi
 
 # Playground
 if [ "$mod_stage" -ge 9 ]; then
     header
-    colourEcho $(GETTEXT "{{3Playground mode}}")
+    colourEcho "`gettext "{{3Playground mode}}"`"
     breakline
     breakline
-    typewriter_echo $(GETTEXT "Try what you have learned, type {{2 python snake --help }} for help") 0 2 1 0
+    typewriter_echo "`gettext "Try what you have learned, type {{2 python snake --help }} for help"`" 0 2 1 0
     # Infinite loop
     while true; do
         # Read command
@@ -316,18 +318,18 @@ if [ "$mod_stage" -ge 9 ]; then
                 breakline
             # Check if command contains reset option
             elif [[ $param == *"--reset"* ]] || [[ $param == *"-r"* ]]; then
-                typewriter_echo $(GETTEXT "{{4 + }} {{3 Make Snake has been reset, closing now...}}") 1 2 1 0
+                typewriter_echo "`gettext "{{4 + }} {{3 Make Snake has been reset, closing now...}}"`" 1 2 1 0
                 exit 0
             else
                 # Clean terminal + header
                 header
-                colourEcho $(GETTEXT "{{3Playground mode}}")
+                colourEcho "`gettext "{{3Playground mode}}"`"
                 breakline
                 breakline
-                colourEcho $(GETTEXT "Remember: type {{2 python snake --help }} for help\n") 0 2 1 0
+                colourEcho "`gettext "Remember: type {{2 python snake --help }} for help\n"`" 0 2 1 0
             fi
         else
-            colourEcho $(GETTEXT "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish.") 0 2 1 0
+            colourEcho "`gettext "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish."`" 0 2 1 0
             breakline
         fi
     done

--- a/bin/make-snake
+++ b/bin/make-snake
@@ -52,15 +52,15 @@ function inputLoop
     while true; do
         read -erp $'    \1\e[96m\2>\1\e[0m\2 ' command
         history -s $command
+        commandstr=$1
         if [ -z "$command" ]; then
-            commandstr=$1
             colourEcho "`eval_gettext "{{6 - }} {{5 Need to enter a command: }} {{2 \\\$commandstr }} {{5 or }} {{2 exit }}"`"
         elif [ "$command" == "$1" ] || [ "$command" == "$2" ]; then
             break
         elif [ "$command" == "exit" ]; then
             exit
         fi
-        colourEcho "`gettext "Type {{2 \$1 }} then {{1 ENTER }}"`"
+        colourEcho "`eval_gettext "Type {{2 \\\$commandstr }} then {{1 ENTER }}"`"
         breakline
     done
 }
@@ -254,7 +254,7 @@ if [ "$mod_stage" -eq 7 ]; then
     breakline
     getLastCreatedTheme
     typewriter_echo "`gettext "It's looking good!"`" 0 2 1 0
-    typewriter_echo "`gettext "Type {{2 python snake -t \$theme_name }} to play with the design that you saved in the editor."`" 0 2 1 0
+    typewriter_echo "`eval_gettext "Type {{2 python snake -t \\\$theme_name }} to play with the design that you saved in the editor."`" 0 2 1 0
     inputLoop "python snake -t $theme_name" "python snake --theme $theme_name"
     python -B $dir -mt $theme_name
     saveLevel

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,10 @@ Maintainer: Team Kano <dev@kano.me>
 Section: admin
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0)
+Build-Depends: debhelper (>=9.0.0), gettext
 
 Package: make-snake
 Architecture: all
 Depends: ${misc:Depends}, rxvt-unicode-256color, python,
- kano-profile (>=1.3-5), kano-toolset (>=1.3-8), kano-settings
+ kano-profile (>=1.3-5), kano-toolset (>=1.3-8), kano-settings, kano-i18n
 Description: Lightweight, configurable snake game running in the console

--- a/debian/install
+++ b/debian/install
@@ -14,3 +14,6 @@ icon/make-snake.app usr/share/applications
 games/* usr/share/applications
 
 media /usr/share/make-snake/
+
+locale/* usr/share/locale/
+

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,5 @@
 #!/usr/bin/make -f
 
 %:
+	cd po && make
 	dh $@

--- a/po/Makefile
+++ b/po/Makefile
@@ -19,6 +19,8 @@ clean: clean_locales
 define run-xgettext
 xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
     --package-name=$(APPNAME) --copyright-holder=$(ORG)
+xgettext -o messages.pot -j -L Shell -k --keyword=GETTEXT ../bin/make-snake \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
 endef
 
 messages:

--- a/po/Makefile
+++ b/po/Makefile
@@ -19,7 +19,7 @@ clean: clean_locales
 define run-xgettext
 xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
     --package-name=$(APPNAME) --copyright-holder=$(ORG)
-xgettext -o messages.pot -j -L Shell -k --keyword=GETTEXT ../bin/make-snake \
+xgettext -o messages.pot -j -L Shell --keyword=eval_gettext ../bin/make-snake \
     --package-name=$(APPNAME) --copyright-holder=$(ORG)
 endef
 

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,0 +1,36 @@
+APPNAME=make-snake
+ORG="Kano Computing Ltd."
+
+MSGLANGS=$(notdir $(wildcard *po))
+MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
+
+.PHONY: clean_locales messages
+
+build: $(MSGOBJS)
+
+update: $(MSGLANGS)
+
+clean_locales:
+	rm -rf ../locale
+
+clean: clean_locales
+	rm -f messages.pot
+
+define run-xgettext
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
+endef
+
+messages:
+	$(run-xgettext)
+
+messages.pot:
+	$(run-xgettext)
+
+%.po: messages.pot
+	msgmerge -N -U $*.po messages.pot
+	touch $*.po
+
+../locale/%/LC_MESSAGES/$(APPNAME).mo: clean_locales
+	mkdir -p $(dir $@)
+	msgfmt -c -o $@ $*.po

--- a/po/PYPOTFILES
+++ b/po/PYPOTFILES
@@ -1,0 +1,8 @@
+../snake/graphics.py
+../snake/parser.py
+../snake/stage.py
+../snake/utils.py
+../snake-editor/controls.py
+../snake-editor/graphics.py
+../snake-editor/menus.py
+../snake-editor/theme.py

--- a/po/ja.po
+++ b/po/ja.po
@@ -28,7 +28,7 @@ msgstr " [ENTER]キーを "
 #: ../snake/graphics.py:41
 #, python-brace-format
 msgid " Use [{0}{1}{2}{3}] to move "
-msgstr "   [{0}{1}{2}{3}]で動ける "
+msgstr "   [{0}{1}{2}{3}]で動ける   "
 
 #: ../snake/graphics.py:65
 msgid "  GAME OVER  "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: make-snake\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-16 21:15+0900\n"
+"POT-Creation-Date: 2016-05-16 23:18+0900\n"
 "PO-Revision-Date: 2016-05-14 08:40+0900\n"
 "Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
 "Language-Team: Japanese\n"
@@ -28,7 +28,7 @@ msgstr " [ENTER]キーを "
 #: ../snake/graphics.py:41
 #, python-brace-format
 msgid " Use [{0}{1}{2}{3}] to move "
-msgstr " [{0}{1}{2}{3}]で動ける "
+msgstr "   [{0}{1}{2}{3}]で動ける "
 
 #: ../snake/graphics.py:65
 msgid "  GAME OVER  "
@@ -313,6 +313,11 @@ msgstr ""
 "{{6 - }} {{5 次のコマンドを入力する: }} {{2 $commandstr }} {{5 又は }} {{2 "
 "exit }}"
 
+#: ../bin/make-snake:63
+#, sh-format
+msgid "Type {{2 $commandstr }} then {{1 ENTER }}"
+msgstr ""
+
 #: ../bin/make-snake:93
 #, sh-format
 msgid "Fantastic! You gained {{2 $gained_exp }} experience points!"
@@ -357,8 +362,7 @@ msgstr "{{2 python snake }}を入力し、{{1 ENTER }}を押して下さい。"
 #: ../bin/make-snake:156
 msgid ""
 "This is a Linux command - a spell that your computer's brain understands."
-msgstr ""
-"これはリナックスのコマンドで、パソコンの頭脳が分かるおまじないなんだ。"
+msgstr "これはリナックスのコマンドで、パソコンの頭脳が分かるおまじないなんだ。"
 
 #: ../bin/make-snake:157
 msgid "You can type {{2 exit }} at any point to quit."
@@ -381,12 +385,13 @@ msgid ""
 "But you can write parameters after {{2 python snake }} to change how the "
 "game works."
 msgstr ""
-"でも{{2 python snake }}の後にパラメーターを加えれば、ゲームの動きを"
-"変えられるんだ。"
+"でも{{2 python snake }}の後にパラメーターを加えれば、ゲームの動きを変えられる"
+"んだ。"
 
 #: ../bin/make-snake:175
 msgid "You can make the board medium size with {{2 python snake -b m }}"
-msgstr "例えば、{{2 python snake -b m }}でボードの大きさを中（medium）に設定できる"
+msgstr ""
+"例えば、{{2 python snake -b m }}でボードの大きさを中（medium）に設定できる"
 
 #: ../bin/make-snake:187
 msgid "{{3Challenge [4/9]: Long live Snake}}"
@@ -406,11 +411,14 @@ msgstr ""
 
 #: ../bin/make-snake:192
 msgid "{{2 python snake }} is a command, and {{2 --lives }} is an argument."
-msgstr "{{2 python snake }}は「コマンド」で、{{2 --lives }}は「引数」と言うんだ。"
+msgstr ""
+"{{2 python snake }}は「コマンド」で、{{2 --lives }}は「引数」と言うんだ。"
 
 #: ../bin/make-snake:193
 msgid "Type {{2 python snake --lives 3 }} to make a game with three lives."
-msgstr "３つのいのちのゲームを作るには{{2 python snake --lives 3 }}をタイプしてみよう。"
+msgstr ""
+"３つのいのちのゲームを作るには{{2 python snake --lives 3 }}をタイプしてみよ"
+"う。"
 
 #: ../bin/make-snake:205
 msgid "{{3Challenge [5/9]: Speed it up}}"
@@ -464,6 +472,13 @@ msgstr "{{3チャレンジ [8/9]: 自分の色を自慢しよう}}"
 msgid "It's looking good!"
 msgstr "かっこいいね！"
 
+#: ../bin/make-snake:257
+#, sh-format
+msgid ""
+"Type {{2 python snake -t $theme_name }} to play with the design that you "
+"saved in the editor."
+msgstr ""
+
 #: ../bin/make-snake:267
 msgid "{{3Challenge [9/9]: Life saver}}"
 msgstr "{{3チャレンジ [9/9]: いのち救い}}"
@@ -493,7 +508,8 @@ msgstr "{{3遊び場モード}}"
 
 #: ../bin/make-snake:290
 msgid "Try what you have learned, type {{2 python snake --help }} for help"
-msgstr "学んだことを試してみよう。{{2 python snake --help }}でコマンドを確認しよう"
+msgstr ""
+"学んだことを試してみよう。{{2 python snake --help }}でコマンドを確認しよう"
 
 #: ../bin/make-snake:321
 msgid "{{4 + }} {{3 Make Snake has been reset, closing now...}}"
@@ -505,5 +521,5 @@ msgstr "忘れずに：ヘルプを見るには{{2 python snake --help }}をタ�
 
 #: ../bin/make-snake:332
 msgid "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish."
-msgstr "ヘルプが必要？{{2 python snake --help }}をタイプして、又は{{2 exit }}で終了。"
-
+msgstr ""
+"ヘルプが必要？{{2 python snake --help }}をタイプして、又は{{2 exit }}で終了。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -56,7 +56,7 @@ msgstr " 終了するには[ENTER]を "
 
 #: ../snake/graphics.py:74
 msgid " Press [ENTER] to continue "
-msgstr " 続くには[ENTER]を "
+msgstr " 続くには[ENTER]を押して "
 
 #: ../snake/graphics.py:169 ../snake-editor/graphics.py:198
 msgid "score:"
@@ -72,7 +72,7 @@ msgstr " 終了するにはQを"
 
 #: ../snake/parser.py:44
 msgid "Press {{1 ENTER }} to try again."
-msgstr "やり直すには{{1 ENTER }}を"
+msgstr "やり直すには{{1 ENTER }}を押して"
 
 #: ../snake/parser.py:57
 msgid "Board size (s | m | l)"
@@ -340,164 +340,170 @@ msgstr "{{1 ENTER }}キーで、これから作るゲームを確認しよう！
 
 #: ../bin/make-snake:150
 msgid "{{3Challenge [2/9]: Your first spell}}"
-msgstr ""
+msgstr "{{3チャレンジ [2/9]: 初めてのおまじない}}"
 
 #: ../bin/make-snake:153
 msgid "Ready to make it?"
-msgstr ""
+msgstr "準備はいいかい？"
 
 #: ../bin/make-snake:154
 msgid "Let's start simple."
-msgstr ""
+msgstr "簡単なところから始めよう。"
 
 #: ../bin/make-snake:155
 msgid "Type {{2 python snake }} then press {{1 ENTER }}."
-msgstr ""
+msgstr "{{2 python snake }}を入力し、{{1 ENTER }}を押して下さい。"
 
 #: ../bin/make-snake:156
 msgid ""
 "This is a Linux command - a spell that your computer's brain understands."
 msgstr ""
+"これはリナックスのコマンドで、パソコンの頭脳が分かるおまじないなんだ。"
 
 #: ../bin/make-snake:157
 msgid "You can type {{2 exit }} at any point to quit."
-msgstr ""
+msgstr "{{2 exit }}をタイプすれば、いつでも中断できる。"
 
 #: ../bin/make-snake:169
 msgid "{{3Challenge [3/9]: Game changer}}"
-msgstr ""
+msgstr "{{3チャレンジ [3/9]: ゲームチェンジャー}}"
 
 #: ../bin/make-snake:172
 msgid "Want to make the game tougher?"
-msgstr ""
+msgstr "ゲームを難しくしようか？"
 
 #: ../bin/make-snake:173
 msgid "{{2 python snake }} launches the game."
-msgstr ""
+msgstr "{{2 python snake }}をタイプすると、ゲームが始まる。"
 
 #: ../bin/make-snake:174
 msgid ""
 "But you can write parameters after {{2 python snake }} to change how the "
 "game works."
 msgstr ""
+"でも{{2 python snake }}の後にパラメーターを加えれば、ゲームの動きを"
+"変えられるんだ。"
 
 #: ../bin/make-snake:175
 msgid "You can make the board medium size with {{2 python snake -b m }}"
-msgstr ""
+msgstr "例えば、{{2 python snake -b m }}でボードの大きさを中（medium）に設定できる"
 
 #: ../bin/make-snake:187
 msgid "{{3Challenge [4/9]: Long live Snake}}"
-msgstr ""
+msgstr "{{3チャレンジ [4/9]: スネーク万歳！}}"
 
 #: ../bin/make-snake:190
 msgid "Another way to change the game is to add extra lives!"
-msgstr ""
+msgstr "もう一つ出来ることは、余分のいのち（live）を追加することだ！"
 
 #: ../bin/make-snake:191
 msgid ""
 "You can add extra lives by adding {{2 --lives }} and a number after {{2 "
 "python snake }}."
 msgstr ""
+"{{2 python snake }}の後に、{{2 --lives }}に数字をタイプすれば、いのちを加える"
+"ことが出来るんだ。"
 
 #: ../bin/make-snake:192
 msgid "{{2 python snake }} is a command, and {{2 --lives }} is an argument."
-msgstr ""
+msgstr "{{2 python snake }}は「コマンド」で、{{2 --lives }}は「引数」と言うんだ。"
 
 #: ../bin/make-snake:193
 msgid "Type {{2 python snake --lives 3 }} to make a game with three lives."
-msgstr ""
+msgstr "３つのいのちのゲームを作るには{{2 python snake --lives 3 }}をタイプしてみよう。"
 
 #: ../bin/make-snake:205
 msgid "{{3Challenge [5/9]: Speed it up}}"
-msgstr ""
+msgstr "{{3チャレンジ [5/9]: もっと速く}}"
 
 #: ../bin/make-snake:208
 msgid "Another way to increase difficulty is by changing the Snake's speed."
-msgstr ""
+msgstr "ゲームを難しくするには、蛇の動く速度を変えることも出来るんだ。"
 
 #: ../bin/make-snake:209
 msgid "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast."
-msgstr ""
+msgstr "{{2 -s}}と言う引数に、{{2 f}}オプションでゲームが速く（fast）なる。"
 
 #: ../bin/make-snake:210
 msgid "Let's try a fast game! {{2 python snake -s f }}"
-msgstr ""
+msgstr "{{2 python snake -s f }}をタイプしてゲームを速くしよう！"
 
 #: ../bin/make-snake:221
 msgid "{{3Challenge [6/9]: Amazon style}}"
-msgstr ""
+msgstr "{{3チャレンジ [6/9]: アマゾンスタイル}}"
 
 #: ../bin/make-snake:224
 msgid "You are changing Snake using computer commands."
-msgstr ""
+msgstr "これまでコマンドでゲームの動きを変えたんだね。"
 
 #: ../bin/make-snake:225
 msgid "Now try modifying its theme (how Snake looks)."
-msgstr ""
+msgstr "次はゲームのテーマ（見た目）を変えてみよう。"
 
 #: ../bin/make-snake:226
 msgid "Type {{2 python snake -t jungle }} to play Amazon style!"
-msgstr ""
+msgstr "{{2 python snake -t jungle }}をタイプし、アマゾン森のテーマを選ぼう！"
 
 #: ../bin/make-snake:237
 msgid "{{3Challenge [7/9]: Make my own theme}}"
-msgstr ""
+msgstr "{{3チャレンジ [7/9]: 自分だけのテーマを作ろう}}"
 
 #: ../bin/make-snake:240
 msgid "Do you know you can even create your own themes?"
-msgstr ""
+msgstr "自分の好きなテーマが作れるって知ってたの？"
 
 #: ../bin/make-snake:241
 msgid "Type {{2 python snake -e }} to open the theme editor."
-msgstr ""
+msgstr "{{2 python snake -e }}をタイプして、テーマのエディターを開こう。"
 
 #: ../bin/make-snake:252
 msgid "{{3Challenge [8/9]: Show your colours}}"
-msgstr ""
+msgstr "{{3チャレンジ [8/9]: 自分の色を自慢しよう}}"
 
 #: ../bin/make-snake:256
 msgid "It's looking good!"
-msgstr ""
+msgstr "かっこいいね！"
 
 #: ../bin/make-snake:267
 msgid "{{3Challenge [9/9]: Life saver}}"
-msgstr ""
+msgstr "{{3チャレンジ [9/9]: いのち救い}}"
 
 #: ../bin/make-snake:270
 msgid ""
 "Use the help option to learn all the different spells, with commands, "
 "arguments, and options."
 msgstr ""
+"ヘルプオプションを使えば、全てのコマンド、引数とオプションを確認できるんだ。"
 
 #: ../bin/make-snake:271
 msgid "Type {{2 python snake --help }} to get help."
-msgstr ""
+msgstr "{{2 python snake --help }}をタイプし、ヘルプを求めよう。"
 
 #: ../bin/make-snake:279
 msgid "{{4 + }} {{3 Great! You've completed Make Snake!}}"
-msgstr ""
+msgstr "{{4 + }} {{3 すごい！これでメークスネークは完了！}}"
 
 #: ../bin/make-snake:280
 msgid "Press {{1 ENTER }} to continue"
-msgstr ""
+msgstr "続くには{{1 ENTER }}を押して"
 
 #: ../bin/make-snake:287 ../bin/make-snake:326
 msgid "{{3Playground mode}}"
-msgstr ""
+msgstr "{{3遊び場モード}}"
 
 #: ../bin/make-snake:290
 msgid "Try what you have learned, type {{2 python snake --help }} for help"
-msgstr ""
+msgstr "学んだことを試してみよう。{{2 python snake --help }}でコマンドを確認しよう"
 
 #: ../bin/make-snake:321
 msgid "{{4 + }} {{3 Make Snake has been reset, closing now...}}"
-msgstr ""
+msgstr "{{4 + }} {{3 メークスネークがリセットされました。終了します…"
 
 #: ../bin/make-snake:329
 msgid "Remember: type {{2 python snake --help }} for help\\n"
-msgstr ""
+msgstr "忘れずに：ヘルプを見るには{{2 python snake --help }}をタイプして\\n"
 
 #: ../bin/make-snake:332
 msgid "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish."
-msgstr ""
+msgstr "ヘルプが必要？{{2 python snake --help }}をタイプして、又は{{2 exit }}で終了。"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: make-snake\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-16 00:14+0900\n"
+"POT-Creation-Date: 2016-05-16 21:15+0900\n"
 "PO-Revision-Date: 2016-05-14 08:40+0900\n"
 "Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
 "Language-Team: Japanese\n"
@@ -304,207 +304,200 @@ msgstr "保存したテーマ"
 msgid "Exit"
 msgstr "終了"
 
-#: ../bin/make-snake:55
+#: ../bin/make-snake:57
+#, sh-format
 msgid ""
-"{{6 - }} {{5 Need to enter a command: }} {{2 $1 }} {{5 or }} {{2 exit }}"
+"{{6 - }} {{5 Need to enter a command: }} {{2 $commandstr }} {{5 or }} {{2 "
+"exit }}"
 msgstr ""
-"{{6 - }} {{5 次のコマンドを入力する: }} {{2 $1 }} {{5 又は }} {{2 exit }}"
+"{{6 - }} {{5 次のコマンドを入力する: }} {{2 $commandstr }} {{5 又は }} {{2 "
+"exit }}"
 
-#: ../bin/make-snake:61
-msgid "{{2 $1 }}をタイプしてから{{1 ENTER }}を"
-msgstr ""
-
-#: ../bin/make-snake:91
+#: ../bin/make-snake:93
 #, sh-format
 msgid "Fantastic! You gained {{2 $gained_exp }} experience points!"
 msgstr "素晴らしい！{{2 $gained_exp }}点を獲得できた！"
 
-#: ../bin/make-snake:122
+#: ../bin/make-snake:124
 msgid "Where were we..."
 msgstr "では続けよう…"
 
-#: ../bin/make-snake:131
+#: ../bin/make-snake:133
 msgid "{{3Challenge [1/9]: Let's play!}}"
 msgstr "{{3チャレンジ [1/9]: 遊ぼう！}}"
 
-#: ../bin/make-snake:134
+#: ../bin/make-snake:136
 msgid "Snake is one of the oldest and coolest games."
 msgstr "ヘビゲームは一番古くて楽しいゲームの一つだ。"
 
-#: ../bin/make-snake:135
+#: ../bin/make-snake:137
 msgid "Eat apples, but don't bite your tail!"
 msgstr "リンゴを食べて、自分の尻尾を噛むな！"
 
-#: ../bin/make-snake:136
+#: ../bin/make-snake:138
 msgid "Press {{1 ENTER }} to see what you'll make!"
-msgstr "これから作るゲームを確認しよう。{{1 ENTER }}キーでスタート"
+msgstr "{{1 ENTER }}キーで、これから作るゲームを確認しよう！"
 
-#: ../bin/make-snake:148
+#: ../bin/make-snake:150
 msgid "{{3Challenge [2/9]: Your first spell}}"
 msgstr ""
 
-#: ../bin/make-snake:151
+#: ../bin/make-snake:153
 msgid "Ready to make it?"
 msgstr ""
 
-#: ../bin/make-snake:152
+#: ../bin/make-snake:154
 msgid "Let's start simple."
 msgstr ""
 
-#: ../bin/make-snake:153
+#: ../bin/make-snake:155
 msgid "Type {{2 python snake }} then press {{1 ENTER }}."
 msgstr ""
 
-#: ../bin/make-snake:154
+#: ../bin/make-snake:156
 msgid ""
 "This is a Linux command - a spell that your computer's brain understands."
 msgstr ""
 
-#: ../bin/make-snake:155
+#: ../bin/make-snake:157
 msgid "You can type {{2 exit }} at any point to quit."
 msgstr ""
 
-#: ../bin/make-snake:167
+#: ../bin/make-snake:169
 msgid "{{3Challenge [3/9]: Game changer}}"
 msgstr ""
 
-#: ../bin/make-snake:170
+#: ../bin/make-snake:172
 msgid "Want to make the game tougher?"
 msgstr ""
 
-#: ../bin/make-snake:171
+#: ../bin/make-snake:173
 msgid "{{2 python snake }} launches the game."
 msgstr ""
 
-#: ../bin/make-snake:172
+#: ../bin/make-snake:174
 msgid ""
 "But you can write parameters after {{2 python snake }} to change how the "
 "game works."
 msgstr ""
 
-#: ../bin/make-snake:173
+#: ../bin/make-snake:175
 msgid "You can make the board medium size with {{2 python snake -b m }}"
 msgstr ""
 
-#: ../bin/make-snake:185
+#: ../bin/make-snake:187
 msgid "{{3Challenge [4/9]: Long live Snake}}"
 msgstr ""
 
-#: ../bin/make-snake:188
+#: ../bin/make-snake:190
 msgid "Another way to change the game is to add extra lives!"
 msgstr ""
 
-#: ../bin/make-snake:189
+#: ../bin/make-snake:191
 msgid ""
 "You can add extra lives by adding {{2 --lives }} and a number after {{2 "
 "python snake }}."
 msgstr ""
 
-#: ../bin/make-snake:190
+#: ../bin/make-snake:192
 msgid "{{2 python snake }} is a command, and {{2 --lives }} is an argument."
 msgstr ""
 
-#: ../bin/make-snake:191
+#: ../bin/make-snake:193
 msgid "Type {{2 python snake --lives 3 }} to make a game with three lives."
 msgstr ""
 
-#: ../bin/make-snake:203
+#: ../bin/make-snake:205
 msgid "{{3Challenge [5/9]: Speed it up}}"
 msgstr ""
 
-#: ../bin/make-snake:206
+#: ../bin/make-snake:208
 msgid "Another way to increase difficulty is by changing the Snake's speed."
 msgstr ""
 
-#: ../bin/make-snake:207
+#: ../bin/make-snake:209
 msgid "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast."
 msgstr ""
 
-#: ../bin/make-snake:208
+#: ../bin/make-snake:210
 msgid "Let's try a fast game! {{2 python snake -s f }}"
 msgstr ""
 
-#: ../bin/make-snake:219
+#: ../bin/make-snake:221
 msgid "{{3Challenge [6/9]: Amazon style}}"
 msgstr ""
 
-#: ../bin/make-snake:222
+#: ../bin/make-snake:224
 msgid "You are changing Snake using computer commands."
 msgstr ""
 
-#: ../bin/make-snake:223
+#: ../bin/make-snake:225
 msgid "Now try modifying its theme (how Snake looks)."
 msgstr ""
 
-#: ../bin/make-snake:224
+#: ../bin/make-snake:226
 msgid "Type {{2 python snake -t jungle }} to play Amazon style!"
 msgstr ""
 
-#: ../bin/make-snake:235
+#: ../bin/make-snake:237
 msgid "{{3Challenge [7/9]: Make my own theme}}"
 msgstr ""
 
-#: ../bin/make-snake:238
+#: ../bin/make-snake:240
 msgid "Do you know you can even create your own themes?"
 msgstr ""
 
-#: ../bin/make-snake:239
+#: ../bin/make-snake:241
 msgid "Type {{2 python snake -e }} to open the theme editor."
 msgstr ""
 
-#: ../bin/make-snake:250
+#: ../bin/make-snake:252
 msgid "{{3Challenge [8/9]: Show your colours}}"
 msgstr ""
 
-#: ../bin/make-snake:254
+#: ../bin/make-snake:256
 msgid "It's looking good!"
 msgstr ""
 
-#: ../bin/make-snake:255
-#, sh-format
-msgid ""
-"Type {{2 python snake -t $theme_name }} to play with the design that you "
-"saved in the editor."
-msgstr ""
-
-#: ../bin/make-snake:265
+#: ../bin/make-snake:267
 msgid "{{3Challenge [9/9]: Life saver}}"
 msgstr ""
 
-#: ../bin/make-snake:268
+#: ../bin/make-snake:270
 msgid ""
 "Use the help option to learn all the different spells, with commands, "
 "arguments, and options."
 msgstr ""
 
-#: ../bin/make-snake:269
+#: ../bin/make-snake:271
 msgid "Type {{2 python snake --help }} to get help."
 msgstr ""
 
-#: ../bin/make-snake:277
+#: ../bin/make-snake:279
 msgid "{{4 + }} {{3 Great! You've completed Make Snake!}}"
 msgstr ""
 
-#: ../bin/make-snake:278
+#: ../bin/make-snake:280
 msgid "Press {{1 ENTER }} to continue"
 msgstr ""
 
-#: ../bin/make-snake:285 ../bin/make-snake:324
+#: ../bin/make-snake:287 ../bin/make-snake:326
 msgid "{{3Playground mode}}"
 msgstr ""
 
-#: ../bin/make-snake:288
+#: ../bin/make-snake:290
 msgid "Try what you have learned, type {{2 python snake --help }} for help"
 msgstr ""
 
-#: ../bin/make-snake:319
+#: ../bin/make-snake:321
 msgid "{{4 + }} {{3 Make Snake has been reset, closing now...}}"
 msgstr ""
 
-#: ../bin/make-snake:327
+#: ../bin/make-snake:329
 msgid "Remember: type {{2 python snake --help }} for help\\n"
 msgstr ""
 
-#: ../bin/make-snake:330
+#: ../bin/make-snake:332
 msgid "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish."
 msgstr ""
+

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: make-snake\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-16 23:18+0900\n"
+"POT-Creation-Date: 2016-05-17 07:51+0900\n"
 "PO-Revision-Date: 2016-05-14 08:40+0900\n"
 "Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
 "Language-Team: Japanese\n"
@@ -155,6 +155,10 @@ msgstr "メークスネーク"
 #: ../snake-editor/controls.py:249 ../snake-editor/menus.py:51
 msgid "Take Screenshot"
 msgstr "スクリーンショットを撮る"
+
+#: ../snake-editor/graphics.py:78
+msgid "Press [ENTER]"
+msgstr "[ENTER]キーを押して"
 
 #: ../snake-editor/graphics.py:104 ../snake-editor/menus.py:50
 msgid "Delete Theme"
@@ -316,7 +320,7 @@ msgstr ""
 #: ../bin/make-snake:63
 #, sh-format
 msgid "Type {{2 $commandstr }} then {{1 ENTER }}"
-msgstr ""
+msgstr "{{2 $commandstr }}をタイプし、{{1 ENTER }}キーを押して"
 
 #: ../bin/make-snake:93
 #, sh-format
@@ -470,7 +474,7 @@ msgstr "{{3チャレンジ [8/9]: 自分の色を自慢しよう}}"
 
 #: ../bin/make-snake:256
 msgid "It's looking good!"
-msgstr "かっこいいね！"
+msgstr "いい感じに出来たね！"
 
 #: ../bin/make-snake:257
 #, sh-format
@@ -478,6 +482,8 @@ msgid ""
 "Type {{2 python snake -t $theme_name }} to play with the design that you "
 "saved in the editor."
 msgstr ""
+"エディターで作ったテーマでプレイするには、{{2 python snake -t $theme_name }}を"
+"タイプしてみよう。"
 
 #: ../bin/make-snake:267
 msgid "{{3Challenge [9/9]: Life saver}}"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: make-snake\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-15 13:56+0900\n"
+"POT-Creation-Date: 2016-05-16 00:14+0900\n"
 "PO-Revision-Date: 2016-05-14 08:40+0900\n"
 "Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
 "Language-Team: Japanese\n"
@@ -23,39 +23,56 @@ msgstr "  SNAKEへようこそ "
 
 #: ../snake/graphics.py:36
 msgid " Press [ENTER] "
-msgstr " [ENTER]を押して下さい "
+msgstr " [ENTER]キーを "
+
+#: ../snake/graphics.py:41
+#, python-brace-format
+msgid " Use [{0}{1}{2}{3}] to move "
+msgstr " [{0}{1}{2}{3}]で動ける "
 
 #: ../snake/graphics.py:65
 msgid "  GAME OVER  "
-msgstr "  ゲームオーバー  "
+msgstr "ゲームオーバー"
 
 #: ../snake/graphics.py:66
 msgid "Score:"
-msgstr "スコア："
+msgstr "スコア:"
 
 #: ../snake/graphics.py:67
 msgid "Speed:"
-msgstr "スピード："
+msgstr "スピード:"
 
 #: ../snake/graphics.py:68
 msgid "Size:"
-msgstr "長さ："
+msgstr "長さ:"
 
 #: ../snake/graphics.py:69
 msgid "Lives:"
-msgstr "いのち："
+msgstr "いのち:"
 
 #: ../snake/graphics.py:72
 msgid " Press [ENTER] to exit "
-msgstr " 終了するには[ENTER]を押して下さい "
+msgstr " 終了するには[ENTER]を "
 
 #: ../snake/graphics.py:74
 msgid " Press [ENTER] to continue "
-msgstr " 続くには[ENTER]を押して下さい "
+msgstr " 続くには[ENTER]を "
+
+#: ../snake/graphics.py:169 ../snake-editor/graphics.py:198
+msgid "score:"
+msgstr "スコア:"
+
+#: ../snake/graphics.py:170 ../snake-editor/graphics.py:199
+msgid "lives:"
+msgstr "いのち:"
+
+#: ../snake/graphics.py:171 ../snake-editor/graphics.py:200
+msgid " Press Q to quit "
+msgstr " 終了するにはQを"
 
 #: ../snake/parser.py:44
 msgid "Press {{1 ENTER }} to try again."
-msgstr "やり直すには{{1 ENTER }}を押して下さい"
+msgstr "やり直すには{{1 ENTER }}を"
 
 #: ../snake/parser.py:57
 msgid "Board size (s | m | l)"
@@ -96,7 +113,7 @@ msgstr "好きなテーマを他の人と共有する"
 #: ../snake/stage.py:44
 #, python-format
 msgid "Can't find board size: %s"
-msgstr "このボードの大きさは見つかりません： %s"
+msgstr "このボードの大きさは見つかりません: %s"
 
 #: ../snake/utils.py:56
 #, python-format
@@ -113,15 +130,15 @@ msgstr "Kanoワールドにログインして下さい"
 
 #: ../snake/utils.py:75
 msgid "    1) Select a theme: "
-msgstr "    1) テーマを選択する： "
+msgstr "    1) テーマを選択する: "
 
 #: ../snake/utils.py:81
 msgid "    2) Write a title: "
-msgstr "    2) タイトルを入力する： "
+msgstr "    2) タイトルを入力する: "
 
 #: ../snake/utils.py:86
 msgid "    3) Write a description: "
-msgstr "    3) 説明を入力する： "
+msgstr "    3) 説明を入力する: "
 
 #: ../snake/utils.py:95
 msgid "Sharing of {} failed. {}\n"
@@ -286,3 +303,208 @@ msgstr "保存したテーマ"
 #: ../snake-editor/menus.py:57
 msgid "Exit"
 msgstr "終了"
+
+#: ../bin/make-snake:55
+msgid ""
+"{{6 - }} {{5 Need to enter a command: }} {{2 $1 }} {{5 or }} {{2 exit }}"
+msgstr ""
+"{{6 - }} {{5 次のコマンドを入力する: }} {{2 $1 }} {{5 又は }} {{2 exit }}"
+
+#: ../bin/make-snake:61
+msgid "{{2 $1 }}をタイプしてから{{1 ENTER }}を"
+msgstr ""
+
+#: ../bin/make-snake:91
+#, sh-format
+msgid "Fantastic! You gained {{2 $gained_exp }} experience points!"
+msgstr "素晴らしい！{{2 $gained_exp }}点を獲得できた！"
+
+#: ../bin/make-snake:122
+msgid "Where were we..."
+msgstr "では続けよう…"
+
+#: ../bin/make-snake:131
+msgid "{{3Challenge [1/9]: Let's play!}}"
+msgstr "{{3チャレンジ [1/9]: 遊ぼう！}}"
+
+#: ../bin/make-snake:134
+msgid "Snake is one of the oldest and coolest games."
+msgstr "ヘビゲームは一番古くて楽しいゲームの一つだ。"
+
+#: ../bin/make-snake:135
+msgid "Eat apples, but don't bite your tail!"
+msgstr "リンゴを食べて、自分の尻尾を噛むな！"
+
+#: ../bin/make-snake:136
+msgid "Press {{1 ENTER }} to see what you'll make!"
+msgstr "これから作るゲームを確認しよう。{{1 ENTER }}キーでスタート"
+
+#: ../bin/make-snake:148
+msgid "{{3Challenge [2/9]: Your first spell}}"
+msgstr ""
+
+#: ../bin/make-snake:151
+msgid "Ready to make it?"
+msgstr ""
+
+#: ../bin/make-snake:152
+msgid "Let's start simple."
+msgstr ""
+
+#: ../bin/make-snake:153
+msgid "Type {{2 python snake }} then press {{1 ENTER }}."
+msgstr ""
+
+#: ../bin/make-snake:154
+msgid ""
+"This is a Linux command - a spell that your computer's brain understands."
+msgstr ""
+
+#: ../bin/make-snake:155
+msgid "You can type {{2 exit }} at any point to quit."
+msgstr ""
+
+#: ../bin/make-snake:167
+msgid "{{3Challenge [3/9]: Game changer}}"
+msgstr ""
+
+#: ../bin/make-snake:170
+msgid "Want to make the game tougher?"
+msgstr ""
+
+#: ../bin/make-snake:171
+msgid "{{2 python snake }} launches the game."
+msgstr ""
+
+#: ../bin/make-snake:172
+msgid ""
+"But you can write parameters after {{2 python snake }} to change how the "
+"game works."
+msgstr ""
+
+#: ../bin/make-snake:173
+msgid "You can make the board medium size with {{2 python snake -b m }}"
+msgstr ""
+
+#: ../bin/make-snake:185
+msgid "{{3Challenge [4/9]: Long live Snake}}"
+msgstr ""
+
+#: ../bin/make-snake:188
+msgid "Another way to change the game is to add extra lives!"
+msgstr ""
+
+#: ../bin/make-snake:189
+msgid ""
+"You can add extra lives by adding {{2 --lives }} and a number after {{2 "
+"python snake }}."
+msgstr ""
+
+#: ../bin/make-snake:190
+msgid "{{2 python snake }} is a command, and {{2 --lives }} is an argument."
+msgstr ""
+
+#: ../bin/make-snake:191
+msgid "Type {{2 python snake --lives 3 }} to make a game with three lives."
+msgstr ""
+
+#: ../bin/make-snake:203
+msgid "{{3Challenge [5/9]: Speed it up}}"
+msgstr ""
+
+#: ../bin/make-snake:206
+msgid "Another way to increase difficulty is by changing the Snake's speed."
+msgstr ""
+
+#: ../bin/make-snake:207
+msgid "We use the {{2 -s}} argument, with an {{2 f}} option to choose fast."
+msgstr ""
+
+#: ../bin/make-snake:208
+msgid "Let's try a fast game! {{2 python snake -s f }}"
+msgstr ""
+
+#: ../bin/make-snake:219
+msgid "{{3Challenge [6/9]: Amazon style}}"
+msgstr ""
+
+#: ../bin/make-snake:222
+msgid "You are changing Snake using computer commands."
+msgstr ""
+
+#: ../bin/make-snake:223
+msgid "Now try modifying its theme (how Snake looks)."
+msgstr ""
+
+#: ../bin/make-snake:224
+msgid "Type {{2 python snake -t jungle }} to play Amazon style!"
+msgstr ""
+
+#: ../bin/make-snake:235
+msgid "{{3Challenge [7/9]: Make my own theme}}"
+msgstr ""
+
+#: ../bin/make-snake:238
+msgid "Do you know you can even create your own themes?"
+msgstr ""
+
+#: ../bin/make-snake:239
+msgid "Type {{2 python snake -e }} to open the theme editor."
+msgstr ""
+
+#: ../bin/make-snake:250
+msgid "{{3Challenge [8/9]: Show your colours}}"
+msgstr ""
+
+#: ../bin/make-snake:254
+msgid "It's looking good!"
+msgstr ""
+
+#: ../bin/make-snake:255
+#, sh-format
+msgid ""
+"Type {{2 python snake -t $theme_name }} to play with the design that you "
+"saved in the editor."
+msgstr ""
+
+#: ../bin/make-snake:265
+msgid "{{3Challenge [9/9]: Life saver}}"
+msgstr ""
+
+#: ../bin/make-snake:268
+msgid ""
+"Use the help option to learn all the different spells, with commands, "
+"arguments, and options."
+msgstr ""
+
+#: ../bin/make-snake:269
+msgid "Type {{2 python snake --help }} to get help."
+msgstr ""
+
+#: ../bin/make-snake:277
+msgid "{{4 + }} {{3 Great! You've completed Make Snake!}}"
+msgstr ""
+
+#: ../bin/make-snake:278
+msgid "Press {{1 ENTER }} to continue"
+msgstr ""
+
+#: ../bin/make-snake:285 ../bin/make-snake:324
+msgid "{{3Playground mode}}"
+msgstr ""
+
+#: ../bin/make-snake:288
+msgid "Try what you have learned, type {{2 python snake --help }} for help"
+msgstr ""
+
+#: ../bin/make-snake:319
+msgid "{{4 + }} {{3 Make Snake has been reset, closing now...}}"
+msgstr ""
+
+#: ../bin/make-snake:327
+msgid "Remember: type {{2 python snake --help }} for help\\n"
+msgstr ""
+
+#: ../bin/make-snake:330
+msgid "Need help? Type {{2 python snake --help }} or {{2 exit }} to finish."
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,288 @@
+# Japanese translations for make-snake package.
+# Copyright (C) 2016 Kano Computing Ltd.
+# This file is distributed under the same license as the make-snake package.
+# Choppin Antoine <antoine@japonophile.com>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: make-snake\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-15 13:56+0900\n"
+"PO-Revision-Date: 2016-05-14 08:40+0900\n"
+"Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../snake/graphics.py:35
+msgid "  Welcome to SNAKE "
+msgstr "  SNAKEへようこそ "
+
+#: ../snake/graphics.py:36
+msgid " Press [ENTER] "
+msgstr " [ENTER]を押して下さい "
+
+#: ../snake/graphics.py:65
+msgid "  GAME OVER  "
+msgstr "  ゲームオーバー  "
+
+#: ../snake/graphics.py:66
+msgid "Score:"
+msgstr "スコア："
+
+#: ../snake/graphics.py:67
+msgid "Speed:"
+msgstr "スピード："
+
+#: ../snake/graphics.py:68
+msgid "Size:"
+msgstr "長さ："
+
+#: ../snake/graphics.py:69
+msgid "Lives:"
+msgstr "いのち："
+
+#: ../snake/graphics.py:72
+msgid " Press [ENTER] to exit "
+msgstr " 終了するには[ENTER]を押して下さい "
+
+#: ../snake/graphics.py:74
+msgid " Press [ENTER] to continue "
+msgstr " 続くには[ENTER]を押して下さい "
+
+#: ../snake/parser.py:44
+msgid "Press {{1 ENTER }} to try again."
+msgstr "やり直すには{{1 ENTER }}を押して下さい"
+
+#: ../snake/parser.py:57
+msgid "Board size (s | m | l)"
+msgstr "ボードの大きさ (s=小 | m=中 | l=大)"
+
+#: ../snake/parser.py:62
+msgid "Game speed (s | m | f)"
+msgstr "ゲームスピード (s=遅 | m=中 | f=速)"
+
+#: ../snake/parser.py:66
+msgid "Number of lives (1 | 2 | 3 | 4 | 5 )"
+msgstr "いのちの数 (1 | 2 | 3 | 4 | 5 )"
+
+#: ../snake/parser.py:70
+msgid "Game themes (classic | minimal | jungle | 80s ) + custom themes"
+msgstr "ゲームのテーマ (classic | minimal | jungle | 80s ) + カスタムテーマ"
+
+#: ../snake/parser.py:74
+msgid "Print all available themes"
+msgstr "全てのテーマを表示"
+
+#: ../snake/parser.py:78
+msgid "Enter editor mode"
+msgstr "エディターモードに入る"
+
+#: ../snake/parser.py:82
+msgid "Closes game after game over"
+msgstr "ゲームオーバー後にゲームを終了する"
+
+#: ../snake/parser.py:86
+msgid "Resets the game to challenge 1"
+msgstr "チャレンジ１にゲームを戻す"
+
+#: ../snake/parser.py:90
+msgid "Share your favourite theme with the world"
+msgstr "好きなテーマを他の人と共有する"
+
+#: ../snake/stage.py:44
+#, python-format
+msgid "Can't find board size: %s"
+msgstr "このボードの大きさは見つかりません： %s"
+
+#: ../snake/utils.py:56
+#, python-format
+msgid "Theme %s not found (names are case sensitive)\n"
+msgstr "テーマ %s が見つかりません（テーマ名で大文字と小文字の区別に注意）\n"
+
+#: ../snake/utils.py:64
+msgid "You need internet connection"
+msgstr "インターネット接続が必要です"
+
+#: ../snake/utils.py:70
+msgid "You need to login to Kano World"
+msgstr "Kanoワールドにログインして下さい"
+
+#: ../snake/utils.py:75
+msgid "    1) Select a theme: "
+msgstr "    1) テーマを選択する： "
+
+#: ../snake/utils.py:81
+msgid "    2) Write a title: "
+msgstr "    2) タイトルを入力する： "
+
+#: ../snake/utils.py:86
+msgid "    3) Write a description: "
+msgstr "    3) 説明を入力する： "
+
+#: ../snake/utils.py:95
+msgid "Sharing of {} failed. {}\n"
+msgstr "{}を共有に失敗しました。{}\n"
+
+#: ../snake-editor/controls.py:139
+msgid "Take Screenshot [TAKEN]"
+msgstr "スクリーンショットを撮る [完了]"
+
+#: ../snake-editor/controls.py:231
+msgid "Make Snake"
+msgstr "メークスネーク"
+
+#: ../snake-editor/controls.py:249 ../snake-editor/menus.py:51
+msgid "Take Screenshot"
+msgstr "スクリーンショットを撮る"
+
+#: ../snake-editor/graphics.py:104 ../snake-editor/menus.py:50
+msgid "Delete Theme"
+msgstr "テーマを削除する"
+
+#: ../snake-editor/menus.py:17 ../snake-editor/theme.py:36
+#: ../snake-editor/theme.py:198
+msgid "Black"
+msgstr "黒"
+
+#: ../snake-editor/menus.py:17 ../snake-editor/theme.py:37
+#: ../snake-editor/theme.py:200
+msgid "Red"
+msgstr "赤"
+
+#: ../snake-editor/menus.py:17 ../snake-editor/theme.py:38
+#: ../snake-editor/theme.py:202
+msgid "Green"
+msgstr "緑"
+
+#: ../snake-editor/menus.py:17 ../snake-editor/theme.py:39
+#: ../snake-editor/theme.py:204
+msgid "Yellow"
+msgstr "黄色"
+
+#: ../snake-editor/menus.py:18 ../snake-editor/theme.py:40
+#: ../snake-editor/theme.py:206
+msgid "Blue"
+msgstr "青"
+
+#: ../snake-editor/menus.py:18 ../snake-editor/theme.py:41
+#: ../snake-editor/theme.py:208
+msgid "Magenta"
+msgstr "マジェンタ"
+
+#: ../snake-editor/menus.py:18 ../snake-editor/theme.py:42
+#: ../snake-editor/theme.py:210
+msgid "Cyan"
+msgstr "シアン"
+
+#: ../snake-editor/menus.py:18 ../snake-editor/theme.py:43
+msgid "White"
+msgstr "白"
+
+#: ../snake-editor/menus.py:21 ../snake-editor/menus.py:24
+#: ../snake-editor/menus.py:27 ../snake-editor/menus.py:31
+#: ../snake-editor/menus.py:36
+msgid "Background colour"
+msgstr "背景の色"
+
+#: ../snake-editor/menus.py:22 ../snake-editor/theme.py:145
+msgid "Snake body"
+msgstr "蛇の体"
+
+#: ../snake-editor/menus.py:23 ../snake-editor/menus.py:26
+#: ../snake-editor/menus.py:29 ../snake-editor/menus.py:35
+#: ../snake-editor/menus.py:37
+msgid "Symbol colour"
+msgstr "シンボルの色"
+
+#: ../snake-editor/menus.py:23 ../snake-editor/menus.py:26
+#: ../snake-editor/menus.py:29 ../snake-editor/menus.py:35
+#: ../snake-editor/menus.py:38 ../snake-editor/menus.py:43
+#: ../snake-editor/menus.py:45 ../snake-editor/menus.py:51
+#: ../snake-editor/menus.py:54 ../snake-editor/menus.py:90
+#: ../snake-editor/theme.py:69
+msgid "Back"
+msgstr "戻る"
+
+#: ../snake-editor/menus.py:25 ../snake-editor/theme.py:155
+msgid "Lives symbol"
+msgstr "いのちのシンボル"
+
+#: ../snake-editor/menus.py:28 ../snake-editor/theme.py:147
+msgid "Apple symbol"
+msgstr "リンゴのシンボル"
+
+#: ../snake-editor/menus.py:32 ../snake-editor/theme.py:149
+msgid "Horizontal symbol"
+msgstr "横棒のシンボル"
+
+#: ../snake-editor/menus.py:33 ../snake-editor/theme.py:151
+msgid "Vertical symbol"
+msgstr "縦棒のシンボル"
+
+#: ../snake-editor/menus.py:34 ../snake-editor/theme.py:153
+msgid "Corner symbol"
+msgstr "角のシンボル"
+
+#: ../snake-editor/menus.py:38 ../snake-editor/theme.py:143
+msgid "Background symbol"
+msgstr "背景のシンボル"
+
+#: ../snake-editor/menus.py:41 ../snake-editor/theme.py:121
+msgid "Snake"
+msgstr "蛇"
+
+#: ../snake-editor/menus.py:42 ../snake-editor/theme.py:127
+msgid "Lives"
+msgstr "いのち"
+
+#: ../snake-editor/menus.py:43 ../snake-editor/theme.py:123
+msgid "Apples"
+msgstr "リンゴ"
+
+#: ../snake-editor/menus.py:44 ../snake-editor/theme.py:119
+msgid "Background"
+msgstr "背景"
+
+#: ../snake-editor/menus.py:45 ../snake-editor/theme.py:125
+msgid "Border"
+msgstr "ボーダー"
+
+#: ../snake-editor/menus.py:46
+msgid "Do you really want to delete this theme?"
+msgstr "このテーマを本当に削除しますか？"
+
+#: ../snake-editor/menus.py:47
+msgid "Yes"
+msgstr "はい"
+
+#: ../snake-editor/menus.py:47
+msgid "No"
+msgstr "いいえ"
+
+#: ../snake-editor/menus.py:49
+msgid "Board"
+msgstr "ボード"
+
+#: ../snake-editor/menus.py:49
+msgid "Elements"
+msgstr "部品"
+
+#: ../snake-editor/menus.py:54
+msgid "Choose a Name"
+msgstr "名前を選ぶ"
+
+#: ../snake-editor/menus.py:57
+msgid "New Theme"
+msgstr "新しいテーマ"
+
+#: ../snake-editor/menus.py:57
+msgid "Saved Themes"
+msgstr "保存したテーマ"
+
+#: ../snake-editor/menus.py:57
+msgid "Exit"
+msgstr "終了"

--- a/snake-editor/__main__.py
+++ b/snake-editor/__main__.py
@@ -13,16 +13,8 @@ import sys
 
 from kano.utils import is_gui
 
-if __name__ == '__main__' and __package__ is None:
-    DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-
-    if not DIR_PATH.startswith('/usr'):
-        sys.path.insert(1, DIR_PATH)
-        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
-    else:
-        LOCALE_PATH = None
-
 import kano_i18n.init
+LOCALE_PATH = '/usr/share/locale'
 kano_i18n.init.install('make-snake', LOCALE_PATH)
 
 

--- a/snake-editor/__main__.py
+++ b/snake-editor/__main__.py
@@ -13,6 +13,18 @@ import sys
 
 from kano.utils import is_gui
 
+if __name__ == '__main__' and __package__ is None:
+    DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+    if not DIR_PATH.startswith('/usr'):
+        sys.path.insert(1, DIR_PATH)
+        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+    else:
+        LOCALE_PATH = None
+
+import kano_i18n.init
+kano_i18n.init.install('make-snake', LOCALE_PATH)
+
 
 def exit():
     """Attempts to tidy up the graphics.

--- a/snake-editor/__main__.py
+++ b/snake-editor/__main__.py
@@ -6,16 +6,16 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 
+import kano_i18n.init
+LOCALE_PATH = '/usr/share/locale'
+kano_i18n.init.install('make-snake', LOCALE_PATH)
+
 import graphics
 import theme
 import gameloop
 import sys
 
 from kano.utils import is_gui
-
-import kano_i18n.init
-LOCALE_PATH = '/usr/share/locale'
-kano_i18n.init.install('make-snake', LOCALE_PATH)
 
 
 def exit():

--- a/snake-editor/controls.py
+++ b/snake-editor/controls.py
@@ -136,7 +136,7 @@ def update():
             # Screenshot
             elif currentMenu[currentIdx][1] == "screenshot":
                 take_screenshot()
-                menus.editMain[3] = ["Take Screenshot [TAKEN]", "screenshot"]
+                menus.editMain[3] = [_("Take Screenshot [TAKEN]"), "screenshot"]
                 return
             # Modify existing theme
             elif currentMenu[currentIdx][1] == "existing":
@@ -228,7 +228,7 @@ def take_screenshot():
     # Remove screenshot if exists
     if os.path.exists(path):
         os.remove(path)
-    window_name = "Make Snake"
+    window_name = _("Make Snake")
     # TODO: add parameter -cx,y,width,height depending on screen size
     # For 1920x1036: -c500,50,1000,800
     cmd = '/usr/bin/kano-screenshot -p %s -a %s &' % (path, window_name)
@@ -246,7 +246,7 @@ def navigate_back():
     currentIdx = 0
     # Reset Screenshot title just in case
     if currentMenu == menus.editMain:
-        menus.editMain[3] = ["Take Screenshot", "screenshot"]
+        menus.editMain[3] = [_("Take Screenshot"), "screenshot"]
     # Redraw with first theme on the list
     if currentMenu == menus.naming:
         theme_name = currentMenu[0][0]

--- a/snake-editor/graphics.py
+++ b/snake-editor/graphics.py
@@ -75,7 +75,7 @@ def drawCurrentMenu():
                     text += ' : ' + controls.tile[0]
                     if len(controls.tile) > 1:
                         text += ' ' + controls.tile[1]
-                        text += '   >> Press [ENTER]'
+                        text += '   >> ' + _('Press [ENTER]')
                     else:
                         text += ' _'
                 else:

--- a/snake-editor/graphics.py
+++ b/snake-editor/graphics.py
@@ -195,9 +195,9 @@ def drawBorders():
 
 def drawText():
     color = theme.get_color('border')
-    drawTile((stage.width / 2) - 4, (-stage.height / 2) - 1, "score:", color)
-    drawTile((-stage.width / 2), (-stage.height / 2) - 1, "lives:", color)
-    drawTile(-5, (stage.height / 2), " Press Q to quit ", color)
+    drawTile((stage.width / 2) - 4, (-stage.height / 2) - 1, _("score:"), color)
+    drawTile((-stage.width / 2), (-stage.height / 2) - 1, _("lives:"), color)
+    drawTile(-5, (stage.height / 2), _(" Press Q to quit "), color)
 
 
 def drawHeader():

--- a/snake-editor/graphics.py
+++ b/snake-editor/graphics.py
@@ -101,7 +101,7 @@ def drawCurrentMenu():
             else:
                 text = '  ' + string[0]
             # Exception: show delete in red if theme is custom-theme
-            if string[0] == 'Delete Theme' and controls.theme_name == os.path.splitext(theme.CUSTOM_THEME)[0]:
+            if string[0] == _('Delete Theme') and controls.theme_name == os.path.splitext(theme.CUSTOM_THEME)[0]:
                 colour = theme.get_color('Red')
             else:
                 colour = theme.get_color('menu')

--- a/snake-editor/menus.py
+++ b/snake-editor/menus.py
@@ -14,47 +14,47 @@ THEMES_DIR = os.path.expanduser('~/Snake-content')
 # List of themes
 naming = []
 
-colors = [["Black", None], ["Red", None], ["Green", None], ["Yellow", None],
-          ["Blue", None], ["Magenta", None], ["Cyan", None], ["White", None]]
+colors = [[_("Black"), None], [_("Red"), None], [_("Green"), None], [_("Yellow"), None],
+          [_("Blue"), None], [_("Magenta"), None], [_("Cyan"), None], [_("White"), None]]
 
 # Elements
-snake = [["Background colour", colors],
-         ["Snake body", "symbols"],
-         ["Symbol colour", colors], ["Back", None]]
-lives = [["Background colour", colors],
-         ["Lives symbol", "symbols"],
-         ["Symbol colour", colors], ["Back", None]]
-apple = [["Background colour", colors],
-         ["Apple symbol", "symbols"],
-         ["Symbol colour", colors], ["Back", None]]
+snake = [[_("Background colour"), colors],
+         [_("Snake body"), "symbols"],
+         [_("Symbol colour"), colors], [_("Back"), None]]
+lives = [[_("Background colour"), colors],
+         [_("Lives symbol"), "symbols"],
+         [_("Symbol colour"), colors], [_("Back"), None]]
+apple = [[_("Background colour"), colors],
+         [_("Apple symbol"), "symbols"],
+         [_("Symbol colour"), colors], [_("Back"), None]]
 # Board
-border = [["Background colour", colors],
-          ["Horizontal symbol", "symbols"],
-          ["Vertical symbol", "symbols"],
-          ["Corner symbol", "symbols"],
-          ["Symbol colour", colors], ["Back", None]]
-background = [["Background colour", colors],
-              ["Symbol colour", colors],
-              ["Background symbol", "symbols"], ["Back", None]]
+border = [[_("Background colour"), colors],
+          [_("Horizontal symbol"), "symbols"],
+          [_("Vertical symbol"), "symbols"],
+          [_("Corner symbol"), "symbols"],
+          [_("Symbol colour"), colors], [_("Back"), None]]
+background = [[_("Background colour"), colors],
+              [_("Symbol colour"), colors],
+              [_("Background symbol"), "symbols"], [_("Back"), None]]
 
 # Edit Menu
-elements = [["Snake", snake],
-            ["Lives", lives],
-            ["Apples", apple], ["Back", None]]
-board = [["Background", background],
-         ["Border", border], ["Back", 0]]
-delete = [["Do you really want to delete this theme?", None],
-          ["Yes", "delete"], ["No", 0]]
+elements = [[_("Snake"), snake],
+            [_("Lives"), lives],
+            [_("Apples"), apple], [_("Back"), None]]
+board = [[_("Background"), background],
+         [_("Border"), border], [_("Back"), 0]]
+delete = [[_("Do you really want to delete this theme?"), None],
+          [_("Yes"), "delete"], [_("No"), 0]]
 
-editMain = [["Board", board], ["Elements", elements],
-            ["Delete Theme", delete],
-            ["Take Screenshot", "screenshot"], ["Back", 0]]
+editMain = [[_("Board"), board], [_("Elements"), elements],
+            [_("Delete Theme"), delete],
+            [_("Take Screenshot"), "screenshot"], [_("Back"), 0]]
 
 # New theme
-newName = [["Choose a Name", "name"], ["Back", 0]]
+newName = [[_("Choose a Name"), "name"], [_("Back"), 0]]
 
 # Main
-main = [["New Theme", newName], ["Saved Themes", naming], ["Exit", None]]
+main = [[_("New Theme"), newName], [_("Saved Themes"), naming], [_("Exit"), None]]
 
 
 def update_naming():
@@ -87,5 +87,5 @@ def update_naming():
                 # Remove .xml extension and add to list
                 s = os.path.splitext(s)[0]
                 naming.append([s, "existing"])
-    naming.append(["Back", 0])
+    naming.append([_("Back"), 0])
     return

--- a/snake-editor/theme.py
+++ b/snake-editor/theme.py
@@ -33,14 +33,14 @@ theme = {
         "border": (curses.COLOR_WHITE, curses.COLOR_YELLOW),
         "lives": (curses.COLOR_RED, curses.COLOR_RED),
         "menu": (curses.COLOR_WHITE, curses.COLOR_BLACK),
-        "Black": (curses.COLOR_WHITE, curses.COLOR_BLACK),
-        "Red": (curses.COLOR_WHITE, curses.COLOR_RED),
-        "Green": (curses.COLOR_WHITE, curses.COLOR_GREEN),
-        "Yellow": (curses.COLOR_WHITE, curses.COLOR_YELLOW),
-        "Blue": (curses.COLOR_WHITE, curses.COLOR_BLUE),
-        "Magenta": (curses.COLOR_WHITE, curses.COLOR_MAGENTA),
-        "Cyan": (curses.COLOR_WHITE, curses.COLOR_CYAN),
-        "White": (curses.COLOR_WHITE, curses.COLOR_WHITE),
+        _("Black"): (curses.COLOR_WHITE, curses.COLOR_BLACK),
+        _("Red"): (curses.COLOR_WHITE, curses.COLOR_RED),
+        _("Green"): (curses.COLOR_WHITE, curses.COLOR_GREEN),
+        _("Yellow"): (curses.COLOR_WHITE, curses.COLOR_YELLOW),
+        _("Blue"): (curses.COLOR_WHITE, curses.COLOR_BLUE),
+        _("Magenta"): (curses.COLOR_WHITE, curses.COLOR_MAGENTA),
+        _("Cyan"): (curses.COLOR_WHITE, curses.COLOR_CYAN),
+        _("White"): (curses.COLOR_WHITE, curses.COLOR_WHITE),
 
     },
     "tiles": {
@@ -66,7 +66,7 @@ def update():
     if name.endswith('.xml'):
         name = os.path.splitext(name)[0]
     # Ignore 'Back'
-    if name != 'Back' and name != 'webload':
+    if name != _('Back') and name != 'webload':
         # refreshes the name before writing to the file
         update_name()
         # create file
@@ -116,15 +116,15 @@ def set_color_theme(category, parameter, value):
             tree = ET.parse(theme_file)
             root = tree.getroot()
             idx = 1
-            if (category == 'Background'):
+            if (category == _('Background')):
                 idx = 0
-            elif (category == 'Snake'):
+            elif (category == _('Snake')):
                 idx = 1
-            elif (category == 'Apples'):
+            elif (category == _('Apples')):
                 idx = 2
-            elif (category == 'Border'):
+            elif (category == _('Border')):
                 idx = 3
-            elif (category == 'Lives'):
+            elif (category == _('Lives')):
                 idx = 4
             root[0][idx].set(parameter, value)
             tree.write(theme_file)
@@ -140,19 +140,19 @@ def set_tiles_theme(category, value):
             tree = ET.parse(theme_file)
             root = tree.getroot()
             idx = 0
-            if (category == 'Background symbol'):
+            if (category == _('Background symbol')):
                 idx = 0
-            elif (category == 'Snake body'):
+            elif (category == _('Snake body')):
                 idx = 1
-            elif (category == 'Apple symbol'):
+            elif (category == _('Apple symbol')):
                 idx = 2
-            elif (category == 'Horizontal symbol'):
+            elif (category == _('Horizontal symbol')):
                 idx = 3
-            elif (category == 'Vertical symbol'):
+            elif (category == _('Vertical symbol')):
                 idx = 4
-            elif (category == 'Corner symbol'):
+            elif (category == _('Corner symbol')):
                 idx = 5
-            elif (category == 'Lives symbol'):
+            elif (category == _('Lives symbol')):
                 idx = 6
             root[1][idx].text = value
             tree.write(theme_file)
@@ -195,19 +195,19 @@ def load_theme():
 
 
 def get_curses_color(string):
-    if string == 'Black':
+    if string == _('Black'):
         return curses.COLOR_BLACK
-    elif string == 'Red':
+    elif string == _('Red'):
         return curses.COLOR_RED
-    elif string == 'Green':
+    elif string == _('Green'):
         return curses.COLOR_GREEN
-    elif string == 'Yellow':
+    elif string == _('Yellow'):
         return curses.COLOR_YELLOW
-    elif string == 'Blue':
+    elif string == _('Blue'):
         return curses.COLOR_BLUE
-    elif string == 'Magenta':
+    elif string == _('Magenta'):
         return curses.COLOR_MAGENTA
-    elif string == 'Cyan':
+    elif string == _('Cyan'):
         return curses.COLOR_CYAN
     else:
         return curses.COLOR_WHITE

--- a/snake/__main__.py
+++ b/snake/__main__.py
@@ -18,6 +18,18 @@ import sys
 import gamestate as gs
 from kano.utils import is_gui
 
+if __name__ == '__main__' and __package__ is None:
+    DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+    if not DIR_PATH.startswith('/usr'):
+        sys.path.insert(1, DIR_PATH)
+        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+    else:
+        LOCALE_PATH = None
+
+import kano_i18n.init
+kano_i18n.init.install('make-snake', LOCALE_PATH)
+
 
 def exit(save_state=True):
     """Attempts to tidy up the graphics, and then save the app state.

--- a/snake/__main__.py
+++ b/snake/__main__.py
@@ -18,16 +18,8 @@ import sys
 import gamestate as gs
 from kano.utils import is_gui
 
-if __name__ == '__main__' and __package__ is None:
-    DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-
-    if not DIR_PATH.startswith('/usr'):
-        sys.path.insert(1, DIR_PATH)
-        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
-    else:
-        LOCALE_PATH = None
-
 import kano_i18n.init
+LOCALE_PATH = '/usr/share/locale'
 kano_i18n.init.install('make-snake', LOCALE_PATH)
 
 

--- a/snake/graphics.py
+++ b/snake/graphics.py
@@ -38,7 +38,7 @@ def drawInitGame():
     up = u"\u2191"
     down = u"\u2193"
     right = u"\u2192"
-    drawTile(-5, 4, _(" Use [{0}{1}{2}{3}] to move ") % (left, up, down, right), theme.get_color('border'))
+    drawTile(-5, 4, _(" Use [{0}{1}{2}{3}] to move ").format(left, up, down, right), theme.get_color('border'))
 
 
 def drawGameOver():

--- a/snake/graphics.py
+++ b/snake/graphics.py
@@ -38,7 +38,7 @@ def drawInitGame():
     up = u"\u2191"
     down = u"\u2193"
     right = u"\u2192"
-    drawTile(-5, 4, " Use [" + left + up + down + right + "] to move ", theme.get_color('border'))
+    drawTile(-5, 4, _(" Use [{0}{1}{2}{3}] to move ") % (left, up, down, right), theme.get_color('border'))
 
 
 def drawGameOver():
@@ -166,9 +166,9 @@ def drawBorders():
 
 def drawText():
     color = theme.get_color('border')
-    drawTile((stage.width / 2) - 4, (-stage.height / 2) - 1, "score:", color)
-    drawTile((-stage.width / 2), (-stage.height / 2) - 1, "lives:", color)
-    drawTile(-5, (stage.height / 2), " Press Q to quit ", color)
+    drawTile((stage.width / 2) - 4, (-stage.height / 2) - 1, _("score:"), color)
+    drawTile((-stage.width / 2), (-stage.height / 2) - 1, _("lives:"), color)
+    drawTile(-5, (stage.height / 2), _(" Press Q to quit "), color)
 
 
 def update():

--- a/snake/graphics.py
+++ b/snake/graphics.py
@@ -32,8 +32,8 @@ def drawTile(x, y, tile='', color=None):
 
 
 def drawInitGame():
-    drawTile(-5, -2, "  Welcome to SNAKE ", theme.get_color('border'))
-    drawTile(-4, 2, " Press [ENTER] ", theme.get_color('border'))
+    drawTile(-5, -2, _("  Welcome to SNAKE "), theme.get_color('border'))
+    drawTile(-4, 2, _(" Press [ENTER] "), theme.get_color('border'))
     left = u"\u2190"
     up = u"\u2191"
     down = u"\u2193"
@@ -62,16 +62,16 @@ def drawGameOver():
         sizeStr = 'Medium'
     elif(size == 'l'):
         sizeStr = 'Large'
-    drawTile(-4, -10, "  GAME OVER  ", theme.get_color('border'))
-    drawTile(-3, -8, "Score:" + str(game.score), theme.get_color('border'))
-    drawTile(-3, -6, "Speed:" + speedStr, theme.get_color('border'))
-    drawTile(-3, -4, "Size:" + sizeStr, theme.get_color('border'))
-    drawTile(-3, -2, "Lives:" + livesStr, theme.get_color('border'))
+    drawTile(-4, -10, _("  GAME OVER  "), theme.get_color('border'))
+    drawTile(-3, -8, _("Score:") + str(game.score), theme.get_color('border'))
+    drawTile(-3, -6, _("Speed:") + speedStr, theme.get_color('border'))
+    drawTile(-3, -4, _("Size:") + sizeStr, theme.get_color('border'))
+    drawTile(-3, -2, _("Lives:") + livesStr, theme.get_color('border'))
 
     if parser.args.tutorial:
-        drawTile(-6, 2, " Press [ENTER] to exit ", theme.get_color('border'))
+        drawTile(-6, 2, _(" Press [ENTER] to exit "), theme.get_color('border'))
     else:
-        drawTile(-7, 2, " Press [ENTER] to continue ", theme.get_color('border'))
+        drawTile(-7, 2, _(" Press [ENTER] to continue "), theme.get_color('border'))
 
 
 def drawScore():

--- a/snake/parser.py
+++ b/snake/parser.py
@@ -41,7 +41,7 @@ class SnakeArgumentParser(ArgumentParser):
         coloured_error, _, _ = run_cmd('colour_echo "{{8 x }} {{7 error: }}"')
         print "\n    " + coloured_error.strip('\n') + message + '\n'
 
-        run_bg('echo "    `colour_echo "Press {{1 ENTER }} to try again."`"')
+        run_bg('echo "    `colour_echo "' + _('Press {{1 ENTER }} to try again.') + '"`"')
         raw_input()
         self.exit(2)
 
@@ -54,40 +54,40 @@ def init():
     parser.add_argument("-b", "--board",
                         action="store", dest="board", default='l',
                         choices=['s', 'm', 'l'],
-                        help="Board size (s | m | l)")
+                        help=_("Board size (s | m | l)"))
 
     parser.add_argument("-s", "--speed",
                         action="store", dest="speed", default='m',
                         choices=['s', 'm', 'f'],
-                        help="Game speed (s | m | f)")
+                        help=_("Game speed (s | m | f)"))
 
     parser.add_argument("-l", "--lives",
                         action="store", dest="lives", default=1, type=int,
-                        help="Number of lives (1 | 2 | 3 | 4 | 5 )")
+                        help=_("Number of lives (1 | 2 | 3 | 4 | 5 )"))
 
     parser.add_argument("-t", "--theme",
                         action="store", dest="theme", default='minimal',
-                        help="Game themes (classic | minimal | jungle | 80s ) + custom themes")
+                        help=_("Game themes (classic | minimal | jungle | 80s ) + custom themes"))
 
     parser.add_argument("-p", "--print",
                         action="store_true", dest="print_themes", default=False,
-                        help="Print all available themes")
+                        help=_("Print all available themes"))
 
     parser.add_argument("-e", "--editor",
                         action="store_true", dest="editor", default=False,
-                        help="Enter editor mode")
+                        help=_("Enter editor mode"))
 
     parser.add_argument("-m", "--modeTutorial",
                         action="store_true", dest="tutorial", default=False,
-                        help="Closes game after game over")
+                        help=_("Closes game after game over"))
 
     parser.add_argument("-r", "--reset",
                         action="store_true", dest="reset", default=False,
-                        help="Resets the game to challenge 1")
+                        help=_("Resets the game to challenge 1"))
 
     parser.add_argument("--share",
                         action="store_true", dest="share", default=False,
-                        help="Share your favourite theme with the world")
+                        help=_("Share your favourite theme with the world"))
 
     args = parser.parse_args()
 

--- a/snake/stage.py
+++ b/snake/stage.py
@@ -41,7 +41,7 @@ def init():
             chosen_size = config.game_sizes_small[parser.args.board]
         passSize = parser.args.board
     except:
-        print "Can't find board size: %s" % (parser.args.board)
+        print _("Can't find board size: %s") % (parser.args.board)
         __main__.exit()
 
     # Calculate width

--- a/snake/utils.py
+++ b/snake/utils.py
@@ -53,7 +53,7 @@ def check_valid_theme(theme):
     if theme not in theme_list:
         coloured_error, _, _ = run_cmd('colour_echo "{{8 x }} {{7 error: }}"')
         print "\n    " + coloured_error.strip('\n') + \
-              'Theme %s not found (names are case sensitive)\n' % theme
+              _('Theme %s not found (names are case sensitive)\n') % theme
         exit(2)
 
 
@@ -61,29 +61,29 @@ def share_theme():
     # Check for internet
     if not is_internet():
         coloured_error, _, _ = run_cmd('colour_echo "{{8 x }} {{7 error: }}"')
-        print "\n    " + coloured_error.strip('\n') + 'You need internet connection'
+        print "\n    " + coloured_error.strip('\n') + _('You need internet connection')
         exit(2)
     # Check for login
     success, _ = login_using_token()
     if not success:
         coloured_error, _, _ = run_cmd('colour_echo "{{8 x }} {{7 error: }}"')
-        print "\n    " + coloured_error.strip('\n') + 'You need to login to Kano World'
+        print "\n    " + coloured_error.strip('\n') + _('You need to login to Kano World')
         exit(2)
     # Print themes
     print_themes(False, False)
     # Select theme dialogue
-    message = "    1) Select a theme: "
+    message = _("    1) Select a theme: ")
     theme = raw_input(message)
     theme += '.xml'
     # Check theme exists
     check_valid_theme(theme)
     # Select title
-    message = "    2) Write a title: "
+    message = _("    2) Write a title: ")
     title = raw_input(message)
     if not title:
         title = 'My snake'
     # Select description
-    message = "    3) Write a description: "
+    message = _("    3) Write a description: ")
     description = raw_input(message)
     # Create json
     create_share_json(theme, title, description)
@@ -92,7 +92,7 @@ def share_theme():
     success, msg = upload_share(filepath, title, 'make-snake')
     if not success:
         coloured_error, _, _ = run_cmd('colour_echo "{{8 x }} {{7 error: }}"')
-        print "\n    " + coloured_error.strip('\n') + 'Sharing of %s failed. %s\n' % (theme, msg)
+        print "\n    " + coloured_error.strip('\n') + _('Sharing of {} failed. {}\n') % (theme, msg)
         exit(2)
     message, _, _ = run_cmd('colour_echo "{{4 + }} {{3 You have shared your theme successfully }}"')
     print "\n    " + message.strip('\n')


### PR DESCRIPTION
This PR adds i18n (internationalization) support to this great app.

Followed the same guidelines as in kano-greeter (see TRANSLATION.md).
I18n support is added both for Python and Bash files.

Also added Japanese translation, as an example.

I built the Debian package and tested it on my Kano after switching language to Japanese (see http://www.rs-online.com/designspark/electronics/knowledge-item/JPN-raspberry-pi-Japanese-version for details).

Let's share Kano awesomeness with non-English speaking children!