### PR TITLE
CI: Transition to new-style Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
 @Library('kanolib')
-import build_deb_pkg
+import autobuild_repo_pkg
 
 
 stage ('Build') {
-    build_deb_pkg 'make-snake', env.BRANCH_NAME, 'scratch'
+    autobuild_repo_pkg 'make-snake'
 }


### PR DESCRIPTION
Use the new Jenkins functions to auto-build and deploy.

As we are releasing this anyway, might as well make this long-overdue change.